### PR TITLE
Add Conditionals to IPv6 states

### DIFF
--- a/ash-linux/SCAPonly/low/CCE-26280-8.sls
+++ b/ash-linux/SCAPonly/low/CCE-26280-8.sls
@@ -24,10 +24,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26280-8' %}
 {%- set stigId = 'V-38543' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-26731-0.sls
+++ b/ash-linux/SCAPonly/low/CCE-26731-0.sls
@@ -22,10 +22,6 @@
 
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26731-0' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.script:

--- a/ash-linux/SCAPonly/low/CCE-26774-0.sls
+++ b/ash-linux/SCAPonly/low/CCE-26774-0.sls
@@ -16,10 +16,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26774-0' %}
 {%- set stigId = 'V-51379' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-26801-1.sls
+++ b/ash-linux/SCAPonly/low/CCE-26801-1.sls
@@ -22,10 +22,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26801-1' %}
 {%- set stigId = 'V-38521' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-26883-9.sls
+++ b/ash-linux/SCAPonly/low/CCE-26883-9.sls
@@ -16,10 +16,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26883-9' %}
 {%- set stigId = 'V-38535' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-26993-6.sls
+++ b/ash-linux/SCAPonly/low/CCE-26993-6.sls
@@ -16,10 +16,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-26993-6' %}
 {%- set stigId = 'V-38537' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-27164-3.sls
+++ b/ash-linux/SCAPonly/low/CCE-27164-3.sls
@@ -49,3 +49,5 @@ setting_{{ scapId }}-{{ parmName }}:
   sysctl.present:
     - name: '{{ parmName }}'
     - value: '{{ parmVal }}'
+    - onlyif:
+      - test -f '/proc/net/if_inet6'

--- a/ash-linux/SCAPonly/low/CCE-27196-5.sls
+++ b/ash-linux/SCAPonly/low/CCE-27196-5.sls
@@ -25,10 +25,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-27196-5' %}
 {%- set stigId = 'V-38655' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/low/CCE-27457-1.sls
+++ b/ash-linux/SCAPonly/low/CCE-27457-1.sls
@@ -16,10 +16,6 @@
 {%- set helperLoc = 'ash-linux/SCAPonly/low/files' %}
 {%- set scapId = 'CCE-27457-1' %}
 {%- set stigId = 'V-38684' %}
-{%- set parmName = 'net.ipv6.conf.default.accept_ra' %}
-{%- set notify_change = 'In-memory configuration of ''{{ parmName }}'' not disab
-led' %}
-{%- set notify_nochange = '''{{ parmName }}'' already disabled' %}
 
 script_{{ scapId }}-describe:
   cmd.run:

--- a/ash-linux/SCAPonly/medium/CCE-26741-9.sls
+++ b/ash-linux/SCAPonly/medium/CCE-26741-9.sls
@@ -18,13 +18,13 @@
 include:
   - ash-linux.authconfig
 
-{%- set scapId = '38693' %}
+{%- set scapId = 'CCE-26741-9' %}
 {%- set helperLoc = 'ash-linux/SCAPonly/medium/files' %}
 {%- set checkFile = '/etc/pam.d/system-auth-ac' %}
 {%- set param_name = 'remember' %}
 {%- set param_value = '24' %}
-{%- set notify_change = 'Passwords'' reuse-interval set to ' + param_value + ' (per STIG ID V-' + scapId + ').' %}
-{%- set notify_nochange = 'Passwords'' reuse-interval already set to ' + param_value + ' (per STIG ID V-' + scapId + ').' %}
+{%- set notify_change = 'Passwords'' reuse-interval set to ' + param_value + ' (per SCAP ID ' + scapId + ').' %}
+{%- set notify_nochange = 'Passwords'' reuse-interval already set to ' + param_value + ' (per SCAP ID ' + scapId + ').' %}
 
 #define macro to set 'remember' to '24'
 {%- macro set_pam_param(scapId, file, param, value, notify_text) %}

--- a/ash-linux/STIGbyID/cat2/V38444.sls
+++ b/ash-linux/STIGbyID/cat2/V38444.sls
@@ -40,13 +40,19 @@ cmd_V{{ stig_id }}-iptablesSet:
     - chain: INPUT
     - policy: DROP
     - family: ipv6
+    - check_cmd:
+      - test -f '/proc/net/if_inet6'
 
 notify_V{{ stig_id }}-iptablesSave:
   cmd.run:
     - name: 'echo "Info: Saving in-memory ip6tables configuration to disk."'
+    - require:
+      - iptables: cmd_V{{ stig_id }}-iptablesSet
 
 iptables_V{{ stig_id }}-iptablesSave:
   module.run:
     - name: 'iptables.save'
     - family: 'ipv6'
+    - require:
+      - iptables: cmd_V{{ stig_id }}-iptablesSet
 {%- endif %}

--- a/ash-linux/STIGbyID/cat2/V38549.sls
+++ b/ash-linux/STIGbyID/cat2/V38549.sls
@@ -26,3 +26,5 @@ service_{{ stigId }}:
     - name: ip6tables
     - running
     - enable: True
+    - onlyif:
+      - test -f '/proc/net/if_inet6'

--- a/ash-linux/STIGbyID/cat2/V38551.sls
+++ b/ash-linux/STIGbyID/cat2/V38551.sls
@@ -29,3 +29,5 @@ service_{{ stigId }}:
     - name: ip6tables
     - running
     - enable: True
+    - onlyif:
+      - test -f '/proc/net/if_inet6'

--- a/ash-linux/STIGbyID/cat2/V38553.sls
+++ b/ash-linux/STIGbyID/cat2/V38553.sls
@@ -27,3 +27,5 @@ service_{{ stigId }}:
     - name: ip6tables
     - running
     - enable: True
+    - onlyif:
+      - test -f '/proc/net/if_inet6'

--- a/ash-linux/STIGbyID/cat3/V38693.sls
+++ b/ash-linux/STIGbyID/cat3/V38693.sls
@@ -17,7 +17,7 @@
 include:
   - ash-linux.authconfig
 
-{%- set stig_id = '38693' %}
+{%- set stig_id = 'V38693' %}
 {%- set helperLoc = 'ash-linux/STIGbyID/cat3/files' %}
 {%- set checkFile = '/etc/pam.d/system-auth-ac' %}
 {%- set param_name = 'maxrepeat' %}
@@ -51,9 +51,9 @@ notify_V{{ stig_id }}-{{ param }}:
     - name: 'echo "{{ notify_text }}"'
 {%- endmacro %}
 
-script_V{{ stig_id }}-describe:
+script_{{ stig_id }}-describe:
   cmd.script:
-    - source: salt://{{ helperLoc }}/V{{ stig_id }}.sh
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
     - cwd: /root
 
 {%- if not salt['file.file_exists'](checkFile) %}

--- a/ash-linux/STIGbyID/cat3/V38693.sls
+++ b/ash-linux/STIGbyID/cat3/V38693.sls
@@ -22,8 +22,8 @@ include:
 {%- set checkFile = '/etc/pam.d/system-auth-ac' %}
 {%- set param_name = 'maxrepeat' %}
 {%- set param_value = '3' %}
-{%- set notify_change = 'Passwords'' repeating characters set to ' + param_value + ' (per STIG ID V-' + stig_id + ').' %}
-{%- set notify_nochange = 'Passwords'' repeating characters already capped at ' + param_value + ' (per STIG ID V-' + stig_id + ').' %}
+{%- set notify_change = 'Passwords'' repeating characters set to ' + param_value + ' (per STIG ID ' + stig_id + ').' %}
+{%- set notify_nochange = 'Passwords'' repeating characters already capped at ' + param_value + ' (per STIG ID ' + stig_id + ').' %}
 
 #define macro to set maxrepeat to '3'
 {%- macro set_pam_param(stig_id, file, param, value, notify_text) %}


### PR DESCRIPTION
Fixes IPv6 state errors when IPv6 is already wholly-disabled (closes #97).

Cleans up miscellaneous issues noted while testing intended fixes (see commit-notes for specifics)