### PR TITLE
Prevent Upstart From Re-populating /etc/securetty

### DIFF
--- a/ash-linux/STIGbyID/cat3/V38494.sls
+++ b/ash-linux/STIGbyID/cat3/V38494.sls
@@ -26,6 +26,14 @@ replace_{{ stigId }}-serialTTY:
     - name: '{{ cfgFile }}'
     - pattern: '^{{ srchPtn }}.*$'
     - repl: ''
+
+comment_{{ stigId }}-serialConf:
+  file.comment:
+    - name: '/etc/init/serial.conf'
+    - regex: ^pre-start exec /sbin/securetty
+    - char: '#'
+    - require:
+      - file: replace_{{ stigId }}-serialTTY
 {%- else %}
 replace_{{ stigId }}-serialTTY:
   cmd.run:


### PR DESCRIPTION
The unaltered upstart file, `/etc/init/serial.conf` will undo the changes implemented in the handler for STIG V-38494. This update uses SaltStack's `file.comment` module to defeat this unwanted behavior.

CLoses #101 