### PR TITLE
Update file-exists if Statement in V38513.sls

### DIFF
--- a/ash-linux/STIGbyID/cat2/V38513.sls
+++ b/ash-linux/STIGbyID/cat2/V38513.sls
@@ -24,7 +24,7 @@ script_V{{ stig_id }}-describe:
     - source: salt://{{ helperLoc }}/V{{ stig_id }}.sh
     - cwd: '/root'
 
-{%- if salt['file.file_exists']({{ file }}) %}
+{%- if salt['file.file_exists'](file) %}
 file_V{{ stig_id }}-repl:
   file.replace:
     - name: {{ file }}


### PR DESCRIPTION
Use of braces in a `{%- if salt['file.file_exists']` statement causes errors (not previously triggered due to exclusion of state from execution.
`