### PR TITLE
Update cat2 init.sls

### DIFF
--- a/ash-linux/STIGbyID/cat2/init.sls
+++ b/ash-linux/STIGbyID/cat2/init.sls
@@ -43,7 +43,7 @@ include:
   - ash-linux.STIGbyID.cat2.V38504
   - ash-linux.STIGbyID.cat2.V38511
   - ash-linux.STIGbyID.cat2.V38512
-#  - ash-linux.STIGbyID.cat2.V38513  # disabled pending fix in v2014.7.5, https://github.com/saltstack/salt/issues/21133
+  - ash-linux.STIGbyID.cat2.V38513
   - ash-linux.STIGbyID.cat2.V38514
   - ash-linux.STIGbyID.cat2.V38515
   - ash-linux.STIGbyID.cat2.V38517


### PR DESCRIPTION
Uncommented: fix in v2014.7.5, (saltstack/salt#21133) tested good on 2016-01-11

