### PR TITLE
`fchownat` needs b64 *and b32

### DIFF
--- a/ash-linux/STIGbyID/cat3/V38554.sls
+++ b/ash-linux/STIGbyID/cat3/V38554.sls
@@ -59,7 +59,9 @@ file_V{{ stig_id }}-auditRules_{{ usertype }}:
     - text: |
         
         # Monitor for SELinux DAC changes (per STIG-ID V-{{ stig_id }})
+        {{ audit_options['rule'] }}
         {{ audit_options['rule32'] }}
+
     {%- endif %}
   {%- endfor %}
 {%- else %}


### PR DESCRIPTION
Per Issue #109, lost b64 rules in favor of b32. This PR adds b64 back so that both b32 and b64 are accounted for on `file.append` operation.

Tested against `file.append` and "already exists" use-case. Does not fix `file.replace` use-case. Will open separate issue to address.