### PR TITLE
Update modprobe.d Rules to Used /bin/true Per Updated  STIG Guidance

### DIFF
--- a/ash-linux/STIGbyID/cat2/V38514.sls
+++ b/ash-linux/STIGbyID/cat2/V38514.sls
@@ -30,7 +30,7 @@ file-V{{ stig_id }}-touchRules:
 file_V{{ stig_id }}-appendBlacklist:
   file.append:
     - name: '{{ file }}'
-    - text: 'install dccp /bin/false'
+    - text: 'install dccp /bin/true'
     - require:
       - file: file-V{{ stig_id }}-touchRules
     - onlyif:

--- a/ash-linux/STIGbyID/cat2/V38515.sls
+++ b/ash-linux/STIGbyID/cat2/V38515.sls
@@ -30,7 +30,7 @@ file-V{{ stig_id }}-touchRules:
 file_V{{ stig_id }}-appendBlacklist:
   file.append:
     - name: '{{ file }}'
-    - text: 'install sctp /bin/false'
+    - text: 'install sctp /bin/true'
     - require:
       - file: file-V{{ stig_id }}-touchRules
     - onlyif:

--- a/ash-linux/STIGbyID/cat2/V38517.sls
+++ b/ash-linux/STIGbyID/cat2/V38517.sls
@@ -30,7 +30,7 @@ file-V{{ stig_id }}-touchRules:
 file_V{{ stig_id }}-appendBlacklist:
   file.append:
     - name: '{{ file }}'
-    - text: 'install tipc /bin/false'
+    - text: 'install tipc /bin/true'
     - require:
       - file: file-V{{ stig_id }}-touchRules
     - onlyif:

--- a/ash-linux/STIGbyID/cat3/V38516.sls
+++ b/ash-linux/STIGbyID/cat3/V38516.sls
@@ -27,7 +27,7 @@ file-V{{ stig_id }}-touchRules:
 file_V{{ stig_id }}-appendBlacklist:
   file.append:
     - name: '{{ file }}'
-    - text: 'install rds /bin/false'
+    - text: 'install rds /bin/true'
     - require:
       - file: file-V{{ stig_id }}-touchRules
     - onlyif:


### PR DESCRIPTION
Fixes #114.