### PR TITLE
Fixes #141

### DIFF
--- a/ash-linux/el7/STIGbyID/cat3/RHEL-07-040370.sls
+++ b/ash-linux/el7/STIGbyID/cat3/RHEL-07-040370.sls
@@ -71,6 +71,8 @@ file_{{ stig_id }}-{{ tsReq }}:
 firewalld_{{ stig_id }}-icmp_blocks-public:
   firewalld.present:
     - name: public
+    - runtime: 'True'
+    - persist: 'True'
     - block_icmp:
       - '{{ tsRep }}'
       - '{{ tsReq }}'


### PR DESCRIPTION
**Note:** as of today's commit-date, the `persist` (and `runtime`) option is only available in the development branches of SaltStack. Hopefully, by the time the EL7 STIGs exit beta, these features will have been pushed into SaltStack's main code-branch.