### PR TITLE
V38513: Manage iptables safety rules in ASH chain

### DIFF
--- a/ash-linux/el6/STIGbyID/cat2/V38513.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38513.sls
@@ -40,7 +40,7 @@ V{{stig_id}}-jump input to ash chain:
     - require:
       - iptables: V{{stig_id}}-create ash chain
 
-V{{stig_id}}-allow established in ash chain:
+V{{stig_id}}-allow established in input chain:
   iptables.insert:
     - position: 1
     - table: filter
@@ -66,6 +66,17 @@ V{{stig_id}}-allow ssh in ash chain:
     - save: true
     - onchanges:
       - iptables: V{{stig_id}}-jump input to ash chain
+    - require_in:
+      - iptables: V{{stig_id}}-set input to drop
+
+V{{stig_id}}-allow lo in input chain:
+  iptables.append:
+    - table: filter
+    - family: ipv4
+    - chain: INPUT
+    - jump: ACCEPT
+    - in-interface: lo
+    - save: true
     - require_in:
       - iptables: V{{stig_id}}-set input to drop
 

--- a/ash-linux/el6/STIGbyID/cat2/V38513.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38513.sls
@@ -37,12 +37,15 @@ V{{stig_id}}-jump input to ash chain:
     - chain: INPUT
     - jump: ASH
     - save: true
+    - require:
+      - iptables: V{{stig_id}}-create ash chain
 
 V{{stig_id}}-allow established in ash chain:
-  iptables.append:
+  iptables.insert:
+    - position: 1
     - table: filter
     - family: ipv4
-    - chain: ASH
+    - chain: INPUT
     - jump: ACCEPT
     - match: state
     - connstate: ESTABLISHED,RELATED
@@ -71,6 +74,8 @@ V{{stig_id}}-set input to drop:
     - chain: INPUT
     - policy: DROP
     - save: true
+    - require:
+      - iptables: V{{stig_id}}-jump input to ash chain
 
 V{{stig_id}}-service running:
   service.running:


### PR DESCRIPTION
Previously, V38513.sls used a jinja test to check for the existence
of `/etc/sysconfig/iptables`, and only created the safety rules for
iptables if the file was missing. However, the `INPUT` table was
_always_ being configured to `DROP`. For systems where this file
already existed, this combination caused the system to become
unreachable because the safety rules were not being added.

This patch updates V38513.sls to use the newer functions and
parameters available in the `iptables` state module to create a new
chain, `ASH`, jump from the `INPUT` chain to the `ASH` chain, and
creates the safety rules in the `ASH` chain.

Creating the saftey rules is conditional on whether the jump rule
is added to the `INPUT` chain. This means users can modify the
`ASH` chain after the fact if they wish to change the default safety
rules.

Fixes #144