### PR TITLE
Handlers for /tmp mount options

### DIFF
--- a/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_nodev.sh
+++ b/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_nodev.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Finding ID:	
+# Version:	mount_option_tmp_nodev
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The nodev mount option can be used to prevent device
+#       files from being created in /tmp. Legitimate character
+#       and block devices should not exist within temporary
+#       directories like /tmp. Add the nodev option to the
+#       fourth column of /etc/fstab for the line which controls
+#       mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.2
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: mount_option_tmp_nodev"
+diag_out "   The only legitimate location for"
+diag_out "   device files is the /dev directory"
+diag_out "   located on the root partition."
+diag_out "----------------------------------------"

--- a/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_noexec.sh
+++ b/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_noexec.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Finding ID:	
+# Version:	mount_option_tmp_noexec
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The noexec mount option can be used to prevent binaries
+#       from being executed out of /tmp. Add the noexec option
+#       to the fourth column of /etc/fstab for the line which
+#       controls mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.4
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: mount_option_tmp_noexec"
+diag_out "   Allowing users to execute binaries"
+diag_out "   from world-writable directories such"
+diag_out "   as /tmp should never be necessary in"
+diag_out "   normal operation and can expose the"
+diag_out "   system to potential compromise."
+diag_out "----------------------------------------"

--- a/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_nosuid.sh
+++ b/ash-linux/el7/VendorSTIG/cat3/files/mount_option_tmp_nosuid.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Finding ID:	
+# Version:	mount_option_tmp_suid
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The nosuid mount option can be used to prevent
+#       execution of setuid programs in /tmp. The SUID and
+#       SGID permissions should not be required in these
+#       world-writable directories. Add the nosuid option to
+#       the fourth column of /etc/fstab for the line which
+#       controls mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.3
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: mount_option_tmp_nosuid"
+diag_out "   The presence of SUID and SGID"
+diag_out "   executables should be tightly"
+diag_out "   controlled. Users should not be able"
+diag_out "   to execute SUID or SGID binaries"
+diag_out "   from temporary storage partitions."
+diag_out "----------------------------------------"

--- a/ash-linux/el7/VendorSTIG/cat3/init.sls
+++ b/ash-linux/el7/VendorSTIG/cat3/init.sls
@@ -1,0 +1,9 @@
+# Add custom handlers for remediations not properly addressed by
+# the vendor's auto-remediation scripts
+#
+#################################################################
+
+include:
+  - ash-linux.el7.VendorSTIG.cat3.mount_option_tmp_nodev
+  - ash-linux.el7.VendorSTIG.cat3.mount_option_tmp_noexec
+  - ash-linux.el7.VendorSTIG.cat3.mount_option_tmp_nosuid

--- a/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_nodev.sls
+++ b/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_nodev.sls
@@ -1,0 +1,76 @@
+# Finding ID:	
+# Version:	mount_option_tmp_nodev
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The nodev mount option can be used to prevent device
+#       files from being created in /tmp. Legitimate character
+#       and block devices should not exist within temporary
+#       directories like /tmp. Add the nodev option to the
+#       fourth column of /etc/fstab for the line which controls
+#       mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.2
+#
+#################################################################
+
+{%- set stig_id = 'mount_option_tmp_nodev' %}
+{%- set helperLoc = 'ash-linux/el7/VendorSTIG/cat3/files' %}
+{%- set targMnt = '/tmp' %}
+{%- set mntOpt = 'nodev' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if salt.file.search('/etc/fstab', targMnt) %}
+  {%- set fstabMnts = salt.mount.fstab() %}
+  {%- set mntDev = fstabMnts[targMnt]['device'] %}
+  {%- set mntDump = fstabMnts[targMnt]['dump'] %}
+  {%- set mntOpts = fstabMnts[targMnt]['opts'] %}
+  {%- set mntPass = fstabMnts[targMnt]['pass'] %}
+  {%- set mntFstype = fstabMnts[targMnt]['fstype'] %}
+
+  {%- if mntOpt in mntOpts %}
+notify_{{ stig_id }}-{{ targMnt }}:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Mount-def for {{ targMnt }} already has {{ mntOpt }} mount-option: state ok.''\n"'
+    - cwd: /root
+    - stateful: True
+  {%- else %}
+    {% do mntOpts.append(mntOpt) %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+  {%- endif %}
+{%- else %}
+  {%- set mntDev = 'tmpfs' %}
+  {%- set mntDump = '0' %}
+  {%- set mntOpts = [ 'noauto', mntOpt ] %}
+  {%- set mntPass = '0' %}
+  {%- set mntFstype = 'tmpfs' %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+{%- endif %}

--- a/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_noexec.sls
+++ b/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_noexec.sls
@@ -1,0 +1,74 @@
+# Finding ID:	
+# Version:	mount_option_tmp_noexec
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The noexec mount option can be used to prevent binaries
+#       from being executed out of /tmp. Add the noexec option
+#       to the fourth column of /etc/fstab for the line which
+#       controls mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.4
+#
+#################################################################
+
+{%- set stig_id = 'mount_option_tmp_noexec' %}
+{%- set helperLoc = 'ash-linux/el7/VendorSTIG/cat3/files' %}
+{%- set targMnt = '/tmp' %}
+{%- set mntOpt = 'noexec' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if salt.file.search('/etc/fstab', targMnt) %}
+  {%- set fstabMnts = salt.mount.fstab() %}
+  {%- set mntDev = fstabMnts[targMnt]['device'] %}
+  {%- set mntDump = fstabMnts[targMnt]['dump'] %}
+  {%- set mntOpts = fstabMnts[targMnt]['opts'] %}
+  {%- set mntPass = fstabMnts[targMnt]['pass'] %}
+  {%- set mntFstype = fstabMnts[targMnt]['fstype'] %}
+
+  {%- if mntOpt in mntOpts %}
+notify_{{ stig_id }}-{{ targMnt }}:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Mount-def for {{ targMnt }} already has {{ mntOpt }} mount-option: state ok.''\n"'
+    - cwd: /root
+    - stateful: True
+  {%- else %}
+    {% do mntOpts.append(mntOpt) %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+  {%- endif %}
+{%- else %}
+  {%- set mntDev = 'tmpfs' %}
+  {%- set mntDump = '0' %}
+  {%- set mntOpts = [ 'noauto', mntOpt ] %}
+  {%- set mntPass = '0' %}
+  {%- set mntFstype = 'tmpfs' %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+{%- endif %}

--- a/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_nosuid.sls
+++ b/ash-linux/el7/VendorSTIG/cat3/mount_option_tmp_nosuid.sls
@@ -1,0 +1,76 @@
+# Finding ID:	
+# Version:	mount_option_tmp_nosuid
+# SRG ID:	
+# Finding Level:	low
+#
+# Rule Summary:
+#       The nosuid mount option can be used to prevent
+#       execution of setuid programs in /tmp. The SUID and
+#       SGID permissions should not be required in these
+#       world-writable directories. Add the nosuid option to
+#       the fourth column of /etc/fstab for the line which
+#       controls mounting of /tmp.
+#
+# CCI-xxxxxx CCI-xxxxxx
+#    NIST SP 800-53 Revision 4 :: CM-7
+#    NIST SP 800-53 Revision 4 :: MP-2
+#    CIS RHEL 7 Benchmark 1.1.0 :: 1.1.3
+#
+#################################################################
+
+{%- set stig_id = 'mount_option_tmp_nosuid' %}
+{%- set helperLoc = 'ash-linux/el7/VendorSTIG/cat3/files' %}
+{%- set targMnt = '/tmp' %}
+{%- set mntOpt = 'nosuid' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if salt.file.search('/etc/fstab', targMnt) %}
+  {%- set fstabMnts = salt.mount.fstab() %}
+  {%- set mntDev = fstabMnts[targMnt]['device'] %}
+  {%- set mntDump = fstabMnts[targMnt]['dump'] %}
+  {%- set mntOpts = fstabMnts[targMnt]['opts'] %}
+  {%- set mntPass = fstabMnts[targMnt]['pass'] %}
+  {%- set mntFstype = fstabMnts[targMnt]['fstype'] %}
+
+  {%- if mntOpt in mntOpts %}
+notify_{{ stig_id }}-{{ targMnt }}:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Mount-def for {{ targMnt }} already has {{ mntOpt }} mount-option: state ok.''\n"'
+    - cwd: /root
+    - stateful: True
+  {%- else %}
+    {% do mntOpts.append(mntOpt) %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+  {%- endif %}
+{%- else %}
+  {%- set mntDev = 'tmpfs' %}
+  {%- set mntDump = '0' %}
+  {%- set mntOpts = [ 'noauto', mntOpt ] %}
+  {%- set mntPass = '0' %}
+  {%- set mntFstype = 'tmpfs' %}
+
+fix_{{ stig_id }}-{{ targMnt }}:
+  module.run:
+    - name: 'mount.set_fstab'
+    - m_name: '{{ targMnt }}'
+    - device: '{{ mntDev }}'
+    - fstype: '{{ mntFstype }}'
+    - opts: '{{ mntOpts|join(",") }}'
+    - dump: '{{ mntDump }}'
+    - pass_num: '{{ mntPass }}'
+
+{%- endif %}

--- a/ash-linux/el7/VendorSTIG/init.sls
+++ b/ash-linux/el7/VendorSTIG/init.sls
@@ -8,6 +8,7 @@
 include:
   - ash-linux.el7.VendorSTIG.packages
   - ash-linux.el7.VendorSTIG.remediate
+  - ash-linux.el7.VendorSTIG.cat3
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010040
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040170
   - ash-linux.el7.VendorSTIG.report

--- a/ash-linux/el7/VendorSTIG/packages.sls
+++ b/ash-linux/el7/VendorSTIG/packages.sls
@@ -11,5 +11,7 @@ packages_{{ stig_id }}-installed:
     - pkgs:
       - openscap
       - openscap-scanner
+{%- if salt.grains.get('os') == 'CentOS' %}
       - openscap-engine-sce
+{%- endif %}
       - scap-security-guide

--- a/ash-linux/el7/VendorSTIG/remediate.sls
+++ b/ash-linux/el7/VendorSTIG/remediate.sls
@@ -5,7 +5,11 @@
 #################################################################
 {%- set stig_id = 'VendorSTIG-top' %}
 {%- set helperLoc = 'ash-linux-formula/ash-linux/el7/VendorSTIG/files' %}
-{%- set dsos = salt.grains.get('os')|lower %}
+{%- if salt.grains.get('os')|lower == 'redhat' %}
+  {%- set dsos = 'rhel' %}
+{%- else %}
+  {%- set dsos = salt.grains.get('os')|lower %}
+{%- endif %}
 {%- set osrel = salt.grains.get('osmajorrelease') %}
 {%- set contentDir = '/usr/share/xml/scap/ssg/content' %}
 {%- set dsfile = 'ssg-' + dsos + osrel + '-ds.xml' %}

--- a/ash-linux/el7/VendorSTIG/report.sls
+++ b/ash-linux/el7/VendorSTIG/report.sls
@@ -6,7 +6,11 @@
 {%- set stig_id = 'VendorSTIG-top' %}
 {%- set helperLoc = 'ash-linux-formula/ash-linux/el7/VendorSTIG/files' %}
 {%- set repDir = '/var/tmp' %}
-{%- set dsos = salt.grains.get('os')|lower %}
+{%- if salt.grains.get('os')|lower == 'redhat' %}
+  {%- set dsos = 'rhel' %}
+{%- else %}
+  {%- set dsos = salt.grains.get('os')|lower %}
+{%- endif %}
 {%- set osrel = salt.grains.get('osmajorrelease') %}
 {%- set contentDir = '/usr/share/xml/scap/ssg/content' %}
 {%- set dsXml = contentDir + '/ssg-' + dsos + osrel + '-ds.xml' %}


### PR DESCRIPTION
Vendor auto-remediation doesn't know how to remediate when /tmp is systemd-managed (as required for tmpfs-based /tmp under EL7)