### PR TITLE
Provides same baseline states for both el6 and el7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ env:
     - SEGFAULT_SIGNALS=all
     - SALT_PILLARROOT=$TRAVIS_BUILD_DIR/tests/pillar/test-linux-main
   matrix:
-    - OS_VERSION=6 SALT_STATE=ash-linux.el6
-    - OS_VERSION=7 SALT_STATE=ash-linux.el7
+    - OS_VERSION=6 SALT_STATE=ash-linux.stig
+    - OS_VERSION=7 SALT_STATE=ash-linux.stig
+    - OS_VERSION=6 SALT_STATE=ash-linux.iavm
+    - OS_VERSION=7 SALT_STATE=ash-linux.iavm
+    - OS_VERSION=6 SALT_STATE=ash-linux.scap
+    - OS_VERSION=7 SALT_STATE=ash-linux.scap
+    - OS_VERSION=6 SALT_STATE=ash-linux.vendor
+    - OS_VERSION=7 SALT_STATE=ash-linux.vendor
+    - OS_VERSION=7 SALT_STATE=ash-linux.el7.stig
 
 services:
   - docker

--- a/ash-linux/el6/SCAPonly/low/CCE-27011-6.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-27011-6.sls
@@ -8,9 +8,9 @@
 #
 # Rule Summary: Disable Kernel Support for USB via Bootloader Configuration
 #
-# Rule Text: Disabling the USB subsystem within the Linux kernel at 
-#            system boot will protect against potentially malicious USB 
-#            devices, although it is only practical in specialized 
+# Rule Text: Disabling the USB subsystem within the Linux kernel at
+#            system boot will protect against potentially malicious USB
+#            devices, although it is only practical in specialized
 #            systems.
 #
 #################################################################
@@ -25,7 +25,10 @@ script_{{ scapId }}-describe:
     - cwd: '/root'
 
 # Disable USB at kernel load
-{%- if salt['file.search'](grubCfgFile, 'kernel') and not salt['file.search'](grubCfgFile, 'kernel.*nousb') %}
+{%-
+    if salt['file.search'](grubCfgFile, 'kernel', ignore_if_missing=True) and not
+       salt['file.search'](grubCfgFile, 'kernel.*nousb', ignore_if_missing=True)
+%}
 
 file_{{ scapId }}-repl:
   file.replace:
@@ -45,4 +48,3 @@ status_{{ scapId }}:
     - name: 'echo "Auditing already enabled at boot"'
 
 {%- endif %}
-

--- a/ash-linux/el6/VendorSTIG/init.sls
+++ b/ash-linux/el6/VendorSTIG/init.sls
@@ -1,0 +1,6 @@
+Print ash-linux el6 vendor baseline help:
+  test.show_notification:
+    - text: |
+        The `ash-linux.vendor` baseline is supported only for EL7. This state
+        is provided only as a notification message and a placeholder. On its
+        own, this state does not modify the system in any way.

--- a/ash-linux/el6/init.sls
+++ b/ash-linux/el6/init.sls
@@ -1,2 +1,0 @@
-include:
-  - ash-linux.el6.STIGbyID

--- a/ash-linux/el7/Nessus/init.sls
+++ b/ash-linux/el7/Nessus/init.sls
@@ -1,0 +1,7 @@
+Print ash-linux el7 Nessus baseline help:
+  test.show_notification:
+    - text: |
+        The ash-linux Nessus baseline for EL7 has no current known findings or
+        remediation actions. This state is provided only as a notification
+        message and a placeholder. On its own, this state does not modify the
+        system in any way.

--- a/ash-linux/el7/SCAPonly/init.sls
+++ b/ash-linux/el7/SCAPonly/init.sls
@@ -1,0 +1,7 @@
+Print ash-linux el7 scap baseline help:
+  test.show_notification:
+    - text: |
+        The `ash-linux.scap` baseline is supported currently only on EL6. For
+        EL7, this state is provided only as a notification  message and a
+        placeholder. On its own, this state does not modify the system in any
+        way.

--- a/ash-linux/el7/STIGbyID/init.sls
+++ b/ash-linux/el7/STIGbyID/init.sls
@@ -1,4 +1,5 @@
-include:
-  - ash-linux.el7.STIGbyID.cat1
-  - ash-linux.el7.STIGbyID.cat2
-  - ash-linux.el7.STIGbyID.cat3
+Print ash-linux el7 stig baseline help:
+  test.show_notification:
+    - text: |
+        The `ash-linux.stig` baseline for EL7 is currently in beta. To apply
+        it, please use the state: `ash-linux.el7.stig`

--- a/ash-linux/el7/init.sls
+++ b/ash-linux/el7/init.sls
@@ -1,2 +1,0 @@
-include:
-  - ash-linux.el7.VendorSTIG

--- a/ash-linux/el7/stig.sls
+++ b/ash-linux/el7/stig.sls
@@ -1,0 +1,4 @@
+include:
+  - ash-linux.el7.STIGbyID.cat1
+  - ash-linux.el7.STIGbyID.cat2
+  - ash-linux.el7.STIGbyID.cat3

--- a/ash-linux/init.sls
+++ b/ash-linux/init.sls
@@ -1,9 +1,9 @@
-{%- if grains['osmajorrelease'] == '7' %}
-include:
-  - ash-linux.el7
-{%- elif grains['osmajorrelease'] == '6' %}
-include:
-  - ash-linux.stig
-  - ash-linux.scap
-  - ash-linux.iavm
-{%- endif %}
+Print ash-linux baseline help:
+  test.show_notification:
+    - text: |
+        Available ash-linux baselines include:
+            ash-linux.stig
+            ash-linux.scap (EL6 only)
+            ash-linux.iavm
+            ash-linux.vendor (EL7 only)
+        See https://github.com/plus3it/ash-linux-formula for more details.

--- a/ash-linux/vendor.sls
+++ b/ash-linux/vendor.sls
@@ -1,0 +1,3 @@
+{%- set ver = grains['osmajorrelease'] %}
+include:
+  - ash-linux.el{{ ver }}.VendorSTIG


### PR DESCRIPTION
* Uses placeholder/notification states where the baseline for either
el6 or el7 do not currently contain any actions.

* Adds tests for all baseline states.

* Creates a top-level `vendor` baseline for the VendorSTIG (EL7 only).