### PR TITLE
Avoids spurious deprecation warning

### DIFF
--- a/ash-linux/el6/STIGbyID/cat2/V38518.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38518.sls
@@ -58,7 +58,7 @@ script_{{ stigId }}-describe:
 # logging-targets defined
 {%- for logFacility in facilityList %}
   {%- set srchPat = '^' + logFacility + '\.' %}
-  {%- if not salt.cmd.shell('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
+  {%- if not salt['cmd.shell']('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
     {%- set cfgStruct = salt['file.grep'](cfgFile, srchPat) %}
     {%- set cfgLine = cfgStruct['stdout'] %}
     {%- set logTarg = cfgLine.split() %}

--- a/ash-linux/el6/STIGbyID/cat2/V38519.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38519.sls
@@ -58,7 +58,7 @@ script_{{ stigId }}-describe:
 # logging-targets defined
 {%- for logFacility in facilityList %}
   {%- set srchPat = '^' + logFacility + '\.' %}
-  {%- if not salt.cmd.shell('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
+  {%- if not salt['cmd.shell']('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
     {%- set cfgStruct = salt['file.grep'](cfgFile, srchPat) %}
     {%- set cfgLine = cfgStruct['stdout'] %}
     {%- set logTarg = cfgLine.split() %}

--- a/ash-linux/el6/STIGbyID/cat2/V38623.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38623.sls
@@ -57,7 +57,7 @@ script_{{ stigId }}-describe:
 # logging-targets defined
 {%- for logFacility in facilityList %}
   {%- set srchPat = '^' + logFacility + '\.' %}
-  {%- if not salt.cmd.shell('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
+  {%- if not salt['cmd.shell']('grep -c -E "' + srchPat + '" ' + cfgFile, output_loglevel='quiet') == '0' %}
     {%- set cfgStruct = salt['file.grep'](cfgFile, srchPat) %}
     {%- set cfgLine = cfgStruct['stdout'] %}
     {%- set logTarg = cfgLine.split() %}

--- a/ash-linux/el6/STIGbyID/cat3/V38530.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38530.sls
@@ -29,11 +29,11 @@ script_V{{ stig_id }}-describe:
 {%- set checkFile = '/etc/localtime' %}
 {%- set newRule = '-w ' + checkFile + ' -p wa -k audit_time_rules' %}
 
-{%- if not salt.cmd.shell('grep -c -E -e "' + newRule + '" ' + auditRules , output_loglevel='quiet') == '0' %}
+{%- if not salt['cmd.shell']('grep -c -E -e "' + newRule + '" ' + auditRules , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}_auditRules:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-{%- elif not salt.cmd.shell('grep -c -E -e "' + checkFile + '" ' + auditRules , output_loglevel='quiet') == '0' %}
+{%- elif not salt['cmd.shell']('grep -c -E -e "' + checkFile + '" ' + auditRules , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}_auditRules:
   file.replace:
     - name: '{{ auditRules }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38540.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38540.sls
@@ -36,7 +36,7 @@ script_V{{ stig_id }}-describe:
 # Will probably want to look at method to do all the edits in one pass:
 # Current method limits rollback capability
 ######################################################################
-{%- if not salt.cmd.shell('grep -c -E -e "' + sPattern + '" ' + audRulCfg , output_loglevel='quiet') == '0' %}
+{%- if not salt['cmd.shell']('grep -c -E -e "' + sPattern + '" ' + audRulCfg , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-sethostname_setdomainname:
   cmd.run:
     - name: 'echo "Appropriate audit-rule already present"'

--- a/ash-linux/el6/STIGbyID/cat3/V38541.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38541.sls
@@ -24,11 +24,11 @@ script_V{{ stig_id }}-describe:
 {%- set rule = '-w ' + audit_path + ' -p wa -k MAC-policy' %}
 {%- set audit_cfg_file = '/etc/audit/audit.rules' %}
 
-{%- if not salt.cmd.shell('grep -c -E -e "' + rule + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+{%- if not salt['cmd.shell']('grep -c -E -e "' + rule + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_selMAC:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-{%- elif not salt.cmd.shell('grep -c -E -e "' + audit_path + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+{%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_path + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_selMAC:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38543.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38543.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38545.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38545.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38547.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38547.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38550.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38550.sls
@@ -40,11 +40,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38552.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38552.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38554.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38554.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38556.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38556.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38557.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38557.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38558.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38558.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38559.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38559.sls
@@ -42,11 +42,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38561.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38561.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38563.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38563.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38565.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38565.sls
@@ -37,11 +37,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38566.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38566.sls
@@ -41,11 +41,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38568.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38568.sls
@@ -35,11 +35,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of mount actions
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38575.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38575.sls
@@ -41,11 +41,11 @@ script_V{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38578.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38578.sls
@@ -28,11 +28,11 @@ script_V{{ stig_id }}-describe:
 {%- set auditRule = '-w ' + checkFile + ' -p wa -k actions' %}
 
 # Monitoring of /etc/sudoers file
-{%- if not salt.cmd.shell('grep -c -E -e "' + auditRule + '" ' + ruleFile , output_loglevel='quiet') == '0' %}
+{%- if not salt['cmd.shell']('grep -c -E -e "' + auditRule + '" ' + ruleFile , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_sudoers:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-{%- elif not salt.cmd.shell('grep -c -E -e "' + checkFile + '" ' + ruleFile , output_loglevel='quiet') == '0' %}
+{%- elif not salt['cmd.shell']('grep -c -E -e "' + checkFile + '" ' + ruleFile , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditRules_sudoers:
   file.replace:
     - name: '{{ ruleFile }}'

--- a/ash-linux/el6/STIGbyID/cat3/V38635.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38635.sls
@@ -25,11 +25,11 @@ script_V{{ stig_id }}-describe:
   {%- set pattern = '-a always,exit -F arch=b64 ' + audit_syscall + ' -k audit_time_rules' %}
   {%- set pattern32 = '-a always,exit -F arch=b32 ' + audit_syscall + ' -k audit_time_rules' %}
   {%- set filename = '/etc/audit/audit.rules' %}
-  {%- if not salt.cmd.shell('grep -c -E -e "' + pattern + '" ' + filename , output_loglevel='quiet') == '0' %}
+  {%- if not salt['cmd.shell']('grep -c -E -e "' + pattern + '" ' + filename , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditTime:
   cmd.run:
     - name: 'echo "Appropriate audit rule already in place"'
-  {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_syscall + '" ' + filename , output_loglevel='quiet') == '0' %}
+  {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_syscall + '" ' + filename , output_loglevel='quiet') == '0' %}
 file_V{{ stig_id }}-auditTime:
   file.replace:
     - name: '/etc/audit/audit.rules'

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010460.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010460.sls
@@ -19,7 +19,7 @@
 {%- set mainCfg = '/boot/grub2/grub.cfg' %}
 {%- set srcCfg = '/etc/grub.d/10_linux' %}
 {%- set dummyPass = '4BadPassw0rd' %}
-{%- set grubPass = salt.cmd.shell('printf "' + dummyPass +
+{%- set grubPass = salt['cmd.shell']('printf "' + dummyPass +
                        '\n' + dummyPass + '\n" | grub2-mkpasswd-pbkdf2 ' +
                        '2>&1 | grep "password is" ' +
                        '| sed "s/^.*password is //"') %}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010470.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010470.sls
@@ -24,7 +24,7 @@
 
 {%- set srcCfg = '/etc/grub.d/10_linux' %}
 {%- set dummyPass = '4BadPassw0rd' %}
-{%- set grubPass = salt.cmd.shell('printf "' + dummyPass + 
+{%- set grubPass = salt['cmd.shell']('printf "' + dummyPass + 
                        '\n' + dummyPass + '\n" | grub2-mkpasswd-pbkdf2 ' +
                        '2>&1 | grep "password is" ' +
                        '| sed "s/^.*password is //"') %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020090.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020090.sls
@@ -32,7 +32,7 @@ script_{{ stig_id }}-describe:
 {%- for userName in salt.user.list_users() %}
 {%- set userInfo = salt.user.info(userName) %}
   {%- if userInfo.gid >= regUserGid %}
-    {%- set seUmap =  salt.cmd.shell('semanage login -ln | awk \'/' + userName + '/{print $2}\'') %}
+    {%- set seUmap =  salt['cmd.shell']('semanage login -ln | awk \'/' + userName + '/{print $2}\'') %}
     {%- if seUmap == "unconfined_u" %}
       {%- do uncUsers.append(userName) %}
     {%- elif seUmap == "staff_u" %}
@@ -55,7 +55,7 @@ set_{{ stig_id }}-SELuserRole-{{ nullUser }}:
   {%- endfor %}
 {%- endif %} 
 
-{%- if not salt.cmd.shell('semanage login -l | awk \'/^__defaul/{ print $2}\'') == stig_role %}
+{%- if not salt['cmd.shell']('semanage login -l | awk \'/^__defaul/{ print $2}\'') == stig_role %}
 notify_{{ stig_id }}-baDefault:
   cmd.run:
     - name: 'printf "[WARNING] Default SEL login user role-mapping is not\n\t\"{{ stig_role }}\": users created after this state runs will\n\tneed to be explicitly set to STIG-compatible roles."'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020250.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020250.sls
@@ -16,8 +16,8 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set maxDays = salt.pillar.get('ash-linux:lookup:mustpatch-days', 30) %}
 {%- set daysToSec = maxDays * 24 * 60 * 60 %}
-{%- set todaysdt = salt.cmd.shell('date "+%s"') %}
-{%- set lastUpdt = salt.cmd.shell("date -d $(yum history 2> /dev/null | awk -F '|' '$4 ~ / U/{print $3}' | head -1 | sed -e 's/^ *//' -e 's/ .*$//') +%s") %}
+{%- set todaysdt = salt['cmd.shell']('date "+%s"') %}
+{%- set lastUpdt = salt['cmd.shell']("date -d $(yum history 2> /dev/null | awk -F '|' '$4 ~ / U/{print $3}' | head -1 | sed -e 's/^ *//' -e 's/ .*$//') +%s") %}
 {%- set dateDiff = todaysdt|int - lastUpdt|int %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020360.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020360.sls
@@ -33,7 +33,7 @@ script_{{ stig_id }}-describe:
 {%- for mount in mounts %}
   {%- set mountType = mountData[mount]['fstype'] %}
   {%- if mountData[mount]['fstype'] in localFstypes %}
-    {%- set foundString = salt.cmd.shell('find ' + mount + ' -xdev -nouser') %}
+    {%- set foundString = salt['cmd.shell']('find ' + mount + ' -xdev -nouser') %}
     {%- set foundList = foundString.split('\n') %}
     {%- do nouserFiles.extend(foundList) %}
   {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020370.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020370.sls
@@ -33,7 +33,7 @@ script_{{ stig_id }}-describe:
 {%- for mount in mounts %}
   {%- set mountType = mountData[mount]['fstype'] %}
   {%- if mountData[mount]['fstype'] in localFstypes %}
-    {%- set foundString = salt.cmd.shell('find ' + mount + ' -xdev -nogroup') %}
+    {%- set foundString = salt['cmd.shell']('find ' + mount + ' -xdev -nogroup') %}
     {%- set foundList = foundString.split('\n') %}
     {%- do nogroupFiles.extend(foundList) %}
   {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020620.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020620.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020620' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList = salt.user.list_users() %}
 {%- set iShells = [
                    '/bin/sh',

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020640.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020640.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020640' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020650.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020650.sls
@@ -18,7 +18,7 @@
 {%- set homeMode = salt.pillar.get('ash-linux:lookup:home-mode', '0750') %}
 {%- set loginDef = '/etc/login.defs' %}
 {%- if salt.file.search(loginDef, 'SYS_UID_MAX') %}
-  {%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+  {%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- else %}
   {%- set sysuserMax = 999 %}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020660.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020660.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set loginDef = '/etc/login.defs' %}
 {%- if salt.file.search(loginDef, 'SYS_UID_MAX') %}
-  {%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+  {%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- else %}
   {%- set sysuserMax = 999 %}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020670.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020670.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set loginDef = '/etc/login.defs' %}
 {%- if salt.file.search(loginDef, 'SYS_UID_MAX') %}
-  {%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+  {%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- else %}
   {%- set sysuserMax = 999 %}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020680.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020680.sls
@@ -18,7 +18,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set loginDef = '/etc/login.defs' %}
 {%- if salt.file.search(loginDef, 'SYS_UID_MAX') %}
-  {%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+  {%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- else %}
   {%- set sysuserMax = 999 %}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020690.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020690.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020690' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList = salt.user.list_users() %}
 {%- set iShells = [
                    '/bin/sh',
@@ -52,8 +52,8 @@ script_{{ stig_id }}-describe:
     {%- set findstr = '-group ' + uGrpLst.replace(',', ' -o -group') %}
     {%- set uhome = uinfo['home'] %}
     {%- set ugid = uinfo['gid'] %}
-    {%- set foundFiles = salt.cmd.shell('find ' + uhome + ' -type f ! \( ' + findstr + ' \)').split('\n') %}
-    {%- set foundDirs = salt.cmd.shell('find ' + uhome + ' -type d ! \( ' + findstr + ' \)').split('\n') %}
+    {%- set foundFiles = salt['cmd.shell']('find ' + uhome + ' -type f ! \( ' + findstr + ' \)').split('\n') %}
+    {%- set foundDirs = salt['cmd.shell']('find ' + uhome + ' -type d ! \( ' + findstr + ' \)').split('\n') %}
     {% for elem in foundFiles %}
       {% if elem %}
 file_{{ stig_id }}-{{ elem }}:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020700.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020700.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set loginDef = '/etc/login.defs' %}
 {%- if salt.file.search(loginDef, 'SYS_UID_MAX') %}
-  {%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+  {%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- else %}
   {%- set sysuserMax = 999 %}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020840.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020840.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020840' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set shinitFiles = [
                        '.bash_login',

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020850.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020850.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020850' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set shinitFiles = [
                        '.bash_login',
@@ -42,7 +42,7 @@ script_{{ stig_id }}-describe:
   {%- set userUid = userInfo['uid']|int %}
   {%- set userGid = userInfo['gid']|string %}
   {%- set gidmap = 'getent group ' + userGid + ' | cut -d : -f 1' %}
-  {%- set userGroup = salt.cmd.shell(gidmap)|string %}
+  {%- set userGroup = salt['cmd.shell'](gidmap)|string %}
   {%- if userUid > sysuserMax %}
     {%- for shinitFile in shinitFiles%}
       {%- if salt.file.file_exists(userHome + '/' + shinitFile) %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020860.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020860.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020860' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set shinitFiles = [
                        '.bash_login',

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020880.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020880.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-020880' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs
 ")|int %}
 {%- set userList = salt.user.list_users() %}
 {%- set iShells = [
@@ -33,7 +33,7 @@
                    '/usr/bin/tcsh',
                    '/usr/bin/zsh'
                     ] %}
-{%- set oWrite = salt.cmd.shell('find / \( -name sys -o -name proc \) -prune -o  -perm -002 -type f -print').split('\n') %}
+{%- set oWrite = salt['cmd.shell']('find / \( -name sys -o -name proc \) -prune -o  -perm -002 -type f -print').split('\n') %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020940.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020940.sls
@@ -27,8 +27,8 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set badDevNodes = [] %}
 {%- if salt.cmd.which('semanage') %}
-  {%- do badDevNodes.extend(salt.cmd.shell('find / -context *:device_t:* \( -type c -o -type b \)').split('\n')) %}
-  {%- do badDevNodes.extend(salt.cmd.shell('find / -context *:unlabeled_t:* \( -type c -o -type b \)').split('\n')) %}
+  {%- do badDevNodes.extend(salt['cmd.shell']('find / -context *:device_t:* \( -type c -o -type b \)').split('\n')) %}
+  {%- do badDevNodes.extend(salt['cmd.shell']('find / -context *:unlabeled_t:* \( -type c -o -type b \)').split('\n')) %}
 {%- endif %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-021010.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-021010.sls
@@ -25,7 +25,7 @@
                     '/usr/local/bin',
                     '/var'
                      ] %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs
 ")|int %}
 {%- set iShells = [
                    '/bin/sh',
@@ -59,7 +59,7 @@ script_{{ stig_id }}-describe:
   {%- if ( uinfo['uid'] > sysuserMax ) and
          ( uinfo['shell'] in iShells ) %}
     {%- set uhome = uinfo['home'] %}
-    {%- set homeMount = salt.cmd.shell('df --output=target ' + uinfo['home'] + ' 2> /dev/null | tail -1') %}
+    {%- set homeMount = salt['cmd.shell']('df --output=target ' + uinfo['home'] + ' 2> /dev/null | tail -1') %}
     {%- if not homeMount in homeDevs %}
       {%- do homeDevs.append(homeMount) %}
     {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-021050.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-021050.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-021050' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set globWrDirs = salt.cmd.shell('find / -perm /002 -type d').split('\n') %}
+{%- set globWrDirs = salt['cmd.shell']('find / -perm /002 -type d').split('\n') %}
 {%- set okUsers = [
                    'root',
                    'sys',
@@ -28,7 +28,7 @@ script_{{ stig_id }}-describe:
     - cwd: /root
 
 {%- for globWrDir in globWrDirs %}
-  {%- set wrDirOwn = salt.cmd.shell('stat -c %G ' + globWrDir) %}
+  {%- set wrDirOwn = salt['cmd.shell']('stat -c %G ' + globWrDir) %}
   {%- if not wrDirOwn in okUsers %}
 fix_{{ stig_id }}-{{ globWrDir }}:
   file.directory:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-021060.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-021060.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-021060' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set shinitFiles = [
                        '.bash_login',

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030310.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030310.sls
@@ -36,7 +36,7 @@ touch_{{ stig_id }}-{{ ruleFile }}:
 
 {%- for mount in mntList %}
   {%- if mntStruct[mount]['fstype'] in localFstypes %}
-    {%- set foundList = salt.cmd.shell('find ' + mount + ' -xdev -type f \( -perm -4000 -o -perm -2000 \)').split('\n') %}
+    {%- set foundList = salt['cmd.shell']('find ' + mount + ' -xdev -type f \( -perm -4000 -o -perm -2000 \)').split('\n') %}
     {%- do privFiles.extend(foundList) %}
   {%- endif %}
 {%- endfor %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030380.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030380.sls
@@ -18,7 +18,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030380' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'chown' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -40,13 +40,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030381.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030381.sls
@@ -18,7 +18,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030381' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fchown' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -40,13 +40,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030382.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030382.sls
@@ -18,7 +18,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030382' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'lchown' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -40,13 +40,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030383.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030383.sls
@@ -18,7 +18,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030383' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fchownat' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -40,13 +40,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030390.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030390.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030390' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'chmod' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030391.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030391.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030391' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fchmod' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030392.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030392.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030392' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fchmodat' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030400.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030400.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030400' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'setxattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030401.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030401.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030401' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fsetxattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030402.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030402.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030402' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'lsetxattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030403.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030403.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030403' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'removexattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030404.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030404.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030404' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'fremovexattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030405.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030405.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030405' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'lremovexattr' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030420.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030420.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030420' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'creat' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030421.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030421.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030421' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'open' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030422.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030422.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030422' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'openat' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030423.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030423.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030423' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'open_by_handle_at' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030424.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030424.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030424' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'truncate' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030425.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030425.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030425' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'ftruncate' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
 {%- set usertypes = {
@@ -38,13 +38,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030441.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030441.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030441' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/semanage' %}
 {%- set actKey = 'privileged-priv_change' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -37,13 +37,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030442.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030442.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030442' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/sebool' %}
 {%- set actKey = 'privileged-priv_change' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -37,13 +37,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030443.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030443.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030443' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/chcon' %}
 {%- set actKey = 'privileged-priv_change' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -37,13 +37,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030444.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030444.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030444' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/restorecon' %}
 {%- set actKey = 'privileged-priv_change' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -37,13 +37,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030510.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030510.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030510' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/passwd' %}
 {%- set key2mon = 'privileged-passwd' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030511.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030511.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030511' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/sbin/unix_chkpwd' %}
 {%- set key2mon = 'privileged-passwd' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030512.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030512.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030512' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/gpasswd' %}
 {%- set key2mon = 'privileged-passwd' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030513.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030513.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030513' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/chage' %}
 {%- set key2mon = 'privileged-passwd' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030514.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030514.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030514' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/userhelper' %}
 {%- set key2mon = 'privileged-passwd' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030521.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030521.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-030521' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/bin/su' %}
 {%- set key2mon = 'privileged-priv_change' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030522.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030522.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-030522' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/sudo' %}
 {%- set key2mon = 'privileged-priv_change' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030524.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030524.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-030524' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/newgrp' %}
 {%- set key2mon = 'privileged-priv_change' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030525.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030525.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-030525' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/chsh' %}
 {%- set key2mon = 'privileged-priv_change' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030526.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030526.sls
@@ -25,7 +25,7 @@
 {%- set stig_id = 'RHEL-07-030526' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/bin/sudoedit' %}
 {%- set key2mon = 'privileged-priv_change' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030530.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030530.sls
@@ -17,7 +17,7 @@
 {%- set stig_id = 'RHEL-07-030530' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/bin/mount' %}
 {%- set key2mon = 'privileged-mount' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030531.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030531.sls
@@ -17,7 +17,7 @@
 {%- set stig_id = 'RHEL-07-030531' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/bin/umount' %}
 {%- set key2mon = 'privileged-mount' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030540.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030540.sls
@@ -17,7 +17,7 @@
 {%- set stig_id = 'RHEL-07-030540' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/postdrop' %}
 {%- set key2mon = 'privileged-postfix' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030541.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030541.sls
@@ -17,7 +17,7 @@
 {%- set stig_id = 'RHEL-07-030541' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/sbin/postqueue' %}
 {%- set key2mon = 'privileged-postfix' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030550.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030550.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030550' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/libexec/openssh/ssh-keysign' %}
 {%- set key2mon = 'privileged-ssh' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030560.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030560.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030560' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/libexec/pt_chown' %}
 {%- set key2mon = 'privileged-terminal' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030561.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030561.sls
@@ -21,7 +21,7 @@
 {%- set stig_id = 'RHEL-07-030561' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/usr/bin/crontab' %}
 {%- set key2mon = 'privileged-cron' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030630.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030630.sls
@@ -15,7 +15,7 @@
 {%- set stig_id = 'RHEL-07-030630' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set ruleFile = '/etc/audit/rules.d/priv_acts.rules' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set path2mon = '/sbin/pam_timestamp_check' %}
 {%- set key2mon = 'privileged-pam' %}
 

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030670.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030670.sls
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030671.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030671.sls
@@ -36,13 +36,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030750.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030750.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030750' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'rename' %}
 {%- set key2mon = 'delete' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -39,13 +39,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030751.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030751.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030751' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'renameat' %}
 {%- set key2mon = 'delete' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -39,13 +39,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030752.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030752.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030752' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'rmdir' %}
 {%- set key2mon = 'delete' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -39,13 +39,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030753.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030753.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030753' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'unlink' %}
 {%- set key2mon = 'delete' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -39,13 +39,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-030754.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-030754.sls
@@ -16,7 +16,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-030754' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs") %}
 {%- set act2mon = 'unlinkat' %}
 {%- set key2mon = 'delete' %}
 {%- set audit_cfg_file = '/etc/audit/rules.d/audit.rules' %}
@@ -39,13 +39,13 @@ script_{{ stig_id }}-describe:
 # Monitoring of SELinux DAC config
 {%- if grains['cpuarch'] == 'x86_64' %}
   {%- for usertype,audit_options in usertypes.items() %}
-    {%- if not salt.cmd.shell('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- if not salt['cmd.shell']('grep -c -E -e "' + audit_options['rule'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   cmd.run:
     - name: 'printf "\nchanged=no comment=''Appropriate audit rule already in place.''\n"'
     - cwd: /root
     - stateful: True
-    {%- elif not salt.cmd.shell('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
+    {%- elif not salt['cmd.shell']('grep -c -E -e "' + audit_options['search_string'] + '" ' + audit_cfg_file , output_loglevel='quiet') == '0' %}
 file_{{ stig_id }}-auditRules_{{ usertype }}:
   file.replace:
     - name: '{{ audit_cfg_file }}'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040250.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040250.sls
@@ -15,7 +15,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-040250' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set fwRule = salt.cmd.shell('firewall-cmd --direct --get-rule ipv4 filter IN_public_allow') %}
+{%- set fwRule = salt['cmd.shell']('firewall-cmd --direct --get-rule ipv4 filter IN_public_allow') %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040350.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040350.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.conf.all.accept_source_route' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040351.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040351.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.conf.default.accept_source_route' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040380.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040380.sls
@@ -18,7 +18,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.icmp_echo_ignore_broadcasts' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '1' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040420.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040420.sls
@@ -18,7 +18,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.conf.default.send_redirects' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040421.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040421.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.conf.all.send_redirects' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040470.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040470.sls
@@ -24,7 +24,7 @@ script_{{ stig_id }}-describe:
     - cwd: /root
 
 {%- for if in ifList %}
-  {%- if salt.cmd.shell('ip link show ' + if + ' | grep ' + ifMode) %}
+  {%- if salt['cmd.shell']('ip link show ' + if + ' | grep ' + ifMode) %}
 property_{{ stig_id }}-{{ if }}:
   cmd.run:
     - name: 'printf "Turning off promiscuous mode on {{ if }} " && ip link set {{ if }} promisc {{ modeTarg }} && echo "...SUCCESS" || echo "...FAILED"'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040640.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040640.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-040640' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set keysList = salt.cmd.shell('find / -name "*key.pub" -type f').split('\n') %}
+{%- set keysList = salt['cmd.shell']('find / -name "*key.pub" -type f').split('\n') %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040650.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040650.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-040650' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
-{%- set keysList = salt.cmd.shell('find / -name "ssh_host*key" -type f').split('\n') %}
+{%- set keysList = salt['cmd.shell']('find / -name "ssh_host*key" -type f').split('\n') %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040730.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040730.sls
@@ -17,7 +17,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv4.ip_forward' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040860.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040860.sls
@@ -16,7 +16,7 @@
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set cfgFile = '/etc/sysctl.conf' %}
 {%- set parmName = 'net.ipv6.conf.all.accept_source_route' %}
-{%- set parmValuCurr = salt.cmd.shell('sysctl -n ' + parmName) %}
+{%- set parmValuCurr = salt['cmd.shell']('sysctl -n ' + parmName) %}
 {%- set parmValuTarg = '0' %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/STIGbyID/cat3/RHEL-07-010490.sls
+++ b/ash-linux/el7/STIGbyID/cat3/RHEL-07-010490.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-010490' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat3/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set bannedAccts = salt.pillar.get('ash-linux:lookup:banned-accts', [

--- a/ash-linux/el7/STIGbyID/cat3/RHEL-07-020300.sls
+++ b/ash-linux/el7/STIGbyID/cat3/RHEL-07-020300.sls
@@ -26,7 +26,7 @@ script_{{ stig_id }}-describe:
 {%- else %}
   {%- for user in userList %}
     {%- set gid = salt.user.info(user)['gid'] %}
-    {%- if not salt.cmd.shell('grep :' + gid|string  + ': /etc/group') %}
+    {%- if not salt['cmd.shell']('grep :' + gid|string  + ': /etc/group') %}
 test_{{ stig_id }}-{{ user }}:
   group.present:
     - name: 'stig_{{ user }}'

--- a/ash-linux/el7/STIGbyID/cat3/RHEL-07-021240.sls
+++ b/ash-linux/el7/STIGbyID/cat3/RHEL-07-021240.sls
@@ -14,7 +14,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-021240' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat3/files' %}
-{%- set sysuserMax = salt.cmd.shell("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
+{%- set sysuserMax = salt['cmd.shell']("awk '/SYS_UID_MAX/{print $2}' /etc/login.defs")|int %}
 {%- set userList =  salt.user.list_users() %}
 {%- set iShells = [
                    '/bin/sh',
@@ -57,7 +57,7 @@ script_{{ stig_id }}-describe:
     {%- if ( userUid >= sysuserMax ) and
            ( userShell in iShells ) %}
       {%- if salt.cmd.retcode('test -d ' + userHome) == 0 %}
-        {%- set homeMount = salt.cmd.shell('df --output=target ' + userHome + ' | tail -1') %}
+        {%- set homeMount = salt['cmd.shell']('df --output=target ' + userHome + ' | tail -1') %}
         {%- if homeMount in banMnt %}
 homedir_{{ stig_id }}-{{ user }}:
   cmd.run:

--- a/ash-linux/el7/STIGbyID/cat3/RHEL-07-040320.sls
+++ b/ash-linux/el7/STIGbyID/cat3/RHEL-07-040320.sls
@@ -17,7 +17,7 @@
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set nsswitchConf = '/etc/nsswitch.conf' %}
 {%- set resolvConf = '/etc/resolv.conf' %}
-{%- set dnsList = salt.cmd.shell("awk '/^nameserver/ {print $2}' " + resolvConf).split('\n') %}
+{%- set dnsList = salt['cmd.shell']("awk '/^nameserver/ {print $2}' " + resolvConf).split('\n') %}
 {%- set dnsList_add = salt.pillar.get('ash-linux:lookup:dns-info:nameservers', []) %}
 
 script_{{ stig_id }}-describe:

--- a/ash-linux/el7/VendorSTIG/cat2/sysctl_kernel_randomize_va_space-patch.sls
+++ b/ash-linux/el7/VendorSTIG/cat2/sysctl_kernel_randomize_va_space-patch.sls
@@ -28,7 +28,7 @@
 {%- set helperLoc = 'ash-linux/el7/VendorSTIG/cat2/files' %}
 {%- set badVal = 'kernelrandomizevaspace' %}
 {%- set gudVal = 'kernel.randomize_va_space' %}
-{%- set fixFiles = salt.cmd.shell('find /etc -type f ! -name "*.bak" | xargs grep -l ' + badVal).split('\n') %}
+{%- set fixFiles = salt['cmd.shell']('find /etc -type f ! -name "*.bak" | xargs grep -l ' + badVal).split('\n') %}
 
 script_{{ stig_id }}-describe:
   cmd.script:


### PR DESCRIPTION
Using the dotted form `salt.cmd.shell` in jinja results in a
spurious DeprecationWarning that says to use cmd.shell instead
of cmd.run. Except we already are. Using the not-dotted form
is a workaround.