### PR TITLE
Sets replace=False when not using a source file

### DIFF
--- a/ash-linux/el6/STIGbyID/cat2/V38449.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38449.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000038
 # Finding Level:	Medium
 #
-#     The /etc/gshadow file must have mode 0000. The /etc/gshadow file 
-#     contains group password hashes. Protection of this file is critical 
+#     The /etc/gshadow file must have mode 0000. The /etc/gshadow file
+#     contains group password hashes. Protection of this file is critical
 #     for system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/gshadow'
     - mode: '0000'
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38450.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38450.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000039
 # Finding Level:	Medium
 #
-#     The /etc/passwd file must be owned by root. The "/etc/passwd" file 
-#     contains information about the users that are configured on the 
+#     The /etc/passwd file must be owned by root. The "/etc/passwd" file
+#     contains information about the users that are configured on the
 #     system. Protection of this file is critical for system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/passwd'
     - user: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38451.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38451.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000040
 # Finding Level:	Medium
 #
-#     The /etc/passwd file must be group-owned by root. The "/etc/passwd" 
-#     file contains information about the users that are configured on the 
+#     The /etc/passwd file must be group-owned by root. The "/etc/passwd"
+#     file contains information about the users that are configured on the
 #     system. Protection of this file is critical for system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/passwd'
     - group: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38457.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38457.sls
@@ -3,9 +3,9 @@
 # Version:	RHEL-06-000041
 # Finding Level:	Medium
 #
-#     The /etc/passwd file must have mode 0644 or less permissive. If the 
-#     "/etc/passwd" file is writable by a group-owner or the world the risk 
-#     of its compromise is increased. The file contains the list of 
+#     The /etc/passwd file must have mode 0644 or less permissive. If the
+#     "/etc/passwd" file is writable by a group-owner or the world the risk
+#     of its compromise is increased. The file contains the list of
 #     accounts on the system and associated information, and ...
 #
 #  CCI: CCI-000366
@@ -27,3 +27,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/passwd'
     - mode: '0644'
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38458.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38458.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000042
 # Finding Level:	Medium
 #
-#     The /etc/group file must be owned by root. The "/etc/group" file 
-#     contains information regarding groups that are configured on the 
+#     The /etc/group file must be owned by root. The "/etc/group" file
+#     contains information regarding groups that are configured on the
 #     system. Protection of this file is important for system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/group'
     - user: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38459.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38459.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000043
 # Finding Level:	Medium
 #
-#     The /etc/group file must be group-owned by root. The "/etc/group" 
-#     file contains information regarding groups that are configured on the 
+#     The /etc/group file must be group-owned by root. The "/etc/group"
+#     file contains information regarding groups that are configured on the
 #     system. Protection of this file is important for system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '/etc/group'
     - group: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38461.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38461.sls
@@ -3,9 +3,9 @@
 # Version:	RHEL-06-000044
 # Finding Level:	Medium
 #
-#     The /etc/group file must have mode 0644 or less permissive. The 
-#     "/etc/group" file contains information regarding groups that are 
-#     configured on the system. Protection of this file is important for 
+#     The /etc/group file must have mode 0644 or less permissive. The
+#     "/etc/group" file contains information regarding groups that are
+#     configured on the system. Protection of this file is important for
 #     system security.
 #
 #  CCI: CCI-000366
@@ -28,3 +28,4 @@ file_{{ stigId }}:
   file.managed:
     - name: '{{ chkFile }}'
     - mode: '0644'
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38502.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38502.sls
@@ -3,9 +3,9 @@
 # Version:	RHEL-06-000033
 # Finding Level:	Medium
 #
-#     The /etc/shadow file must be owned by root. The "/etc/shadow" file 
-#     contains the list of local system accounts and stores password 
-#     hashes. Protection of this file is critical for system security. 
+#     The /etc/shadow file must be owned by root. The "/etc/shadow" file
+#     contains the list of local system accounts and stores password
+#     hashes. Protection of this file is critical for system security.
 #     Failure to give ownership of this file to root ...
 #
 #  CCI: CCI-000366
@@ -27,3 +27,4 @@ file_{{ stigId }}:
   file.managed:
     - name: /etc/shadow
     - user: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38503.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38503.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000034
 # Finding Level:	Medium
 #
-#     The /etc/shadow file must be group-owned by root. The "/etc/shadow" 
-#     file stores password hashes. Protection of this file is critical for 
+#     The /etc/shadow file must be group-owned by root. The "/etc/shadow"
+#     file stores password hashes. Protection of this file is critical for
 #     system security.
 #
 #  CCI: CCI-000366
@@ -26,3 +26,4 @@ file_{{ stigId }}:
   file.managed:
     - name: /etc/shadow
     - group: root
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38504.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38504.sls
@@ -3,9 +3,9 @@
 # Version:	RHEL-06-000035
 # Finding Level:	Medium
 #
-#     The /etc/shadow file must have mode 0000. The "/etc/shadow" file 
-#     contains the list of local system accounts and stores password 
-#     hashes. Protection of this file is critical for system security. 
+#     The /etc/shadow file must have mode 0000. The "/etc/shadow" file
+#     contains the list of local system accounts and stores password
+#     hashes. Protection of this file is critical for system security.
 #     Failure to give ownership of this file to root ...
 #
 #  CCI: CCI-000366
@@ -27,3 +27,4 @@ file_{{ stigId }}:
   file.managed:
     - name: /etc/shadow
     - mode: 0000
+    - replace: False

--- a/ash-linux/el6/STIGbyID/cat2/V38524.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38524.sls
@@ -5,8 +5,8 @@
 # SCAP Security ID: 	CCE-27027-2
 # Finding Level:	Medium
 #
-#     The system must not accept ICMPv4 redirect packets on any interface. 
-#     Accepting ICMP redirects has few legitimate uses. It should be 
+#     The system must not accept ICMPv4 redirect packets on any interface.
+#     Accepting ICMP redirects has few legitimate uses. It should be
 #     disabled unless it is absolutely required.
 #
 #  CCI: CCI-000366
@@ -37,10 +37,11 @@ sysctl_V{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_V{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_V{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat2/V38526.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38526.sls
@@ -5,9 +5,9 @@
 # SCAP Security ID:	CCE-26854-0
 # Finding Level:	Medium
 #
-#     The system must not accept ICMPv4 secure redirect packets on any 
-#     interface. Accepting "secure" ICMP redirects (from those gateways 
-#     listed as default gateways) has few legitimate uses. It should be 
+#     The system must not accept ICMPv4 secure redirect packets on any
+#     interface. Accepting "secure" ICMP redirects (from those gateways
+#     listed as default gateways) has few legitimate uses. It should be
 #     disabled unless it is absolutely required.
 #
 #  CCI: CCI-000366
@@ -38,10 +38,11 @@ sysctl_V{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_V{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_V{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat2/V38532.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38532.sls
@@ -5,9 +5,9 @@
 # SCAP Security ID:	CCE-26831-8
 # Finding Level:	Medium
 #
-#     The system must not accept ICMPv4 secure redirect packets by default. 
-#     Accepting "secure" ICMP redirects (from those gateways listed as 
-#     default gateways) has few legitimate uses. It should be disabled 
+#     The system must not accept ICMPv4 secure redirect packets by default.
+#     Accepting "secure" ICMP redirects (from those gateways listed as
+#     default gateways) has few legitimate uses. It should be disabled
 #     unless it is absolutely required.
 #
 #  CCI: CCI-000366
@@ -40,10 +40,11 @@ sysctl_{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat2/V38542.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38542.sls
@@ -5,10 +5,10 @@
 # SCAP Security ID:	CCE-26979-5
 # Finding Level:	Medium
 #
-#     The system must use a reverse-path filter for IPv4 network traffic 
-#     when possible on all interfaces. Enabling reverse path filtering 
-#     drops packets with source addresses that should not have been able to 
-#     be received on the interface they were received on. It should not be 
+#     The system must use a reverse-path filter for IPv4 network traffic
+#     when possible on all interfaces. Enabling reverse path filtering
+#     drops packets with source addresses that should not have been able to
+#     be received on the interface they were received on. It should not be
 #     used on systems which are ...
 #
 #  CCI: CCI-000366
@@ -41,10 +41,11 @@ sysctl_{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat2/V38579.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38579.sls
@@ -25,6 +25,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-bootGrubGrub:
   file.managed:
     - name: '/boot/grub/grub.conf'
+    - replace: False
     - user: root
 
 file_{{ stig_id }}-etcGrub:

--- a/ash-linux/el6/STIGbyID/cat2/V38581.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38581.sls
@@ -26,6 +26,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-bootGrubGrub:
   file.managed:
     - name: '/boot/grub/grub.conf'
+    - replace: False
     - group: root
 
 file_{{ stig_id }}-etcGrub:

--- a/ash-linux/el6/STIGbyID/cat2/V38583.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38583.sls
@@ -26,6 +26,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-bootGrubGrub:
   file.managed:
     - name: '/boot/grub/grub.conf'
+    - replace: False
     - mode: 0600
 
 file_{{ stig_id }}-etcGrub:

--- a/ash-linux/el6/STIGbyID/cat2/V38600.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38600.sls
@@ -5,9 +5,9 @@
 # SCAP Security ID:	CCE-27001-7
 # Finding Level:	Medium
 #
-#     The system must not send ICMPv4 redirects by default. Sending ICMP 
-#     redirects permits the system to instruct other systems to update 
-#     their routing information. The ability to send ICMP redirects is only 
+#     The system must not send ICMPv4 redirects by default. Sending ICMP
+#     redirects permits the system to instruct other systems to update
+#     their routing information. The ability to send ICMP redirects is only
 #     appropriate for routers.
 #
 #  CCI: CCI-000366
@@ -39,10 +39,11 @@ sysctl_V{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_V{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_V{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat3/V38535.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38535.sls
@@ -5,9 +5,9 @@
 # SCAP Security ID:	CCE-26883-9
 # Finding Level:	Low
 #
-#     The system must not respond to ICMPv4 sent to a broadcast address. 
-#     Ignoring ICMP echo requests (pings) sent to broadcast or multicast 
-#     addresses makes the system slightly more difficult to enumerate on 
+#     The system must not respond to ICMPv4 sent to a broadcast address.
+#     Ignoring ICMP echo requests (pings) sent to broadcast or multicast
+#     addresses makes the system slightly more difficult to enumerate on
 #     the network.
 #
 #  CCI: CCI-000366
@@ -39,10 +39,11 @@ sysctl_V{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_V{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_V{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el6/STIGbyID/cat3/V38537.sls
+++ b/ash-linux/el6/STIGbyID/cat3/V38537.sls
@@ -5,8 +5,8 @@
 # SCAP Security ID:	CCE-26993-6
 # Finding Level:	Low
 #
-#     The system must ignore ICMPv4 bogus error responses. Ignoring bogus 
-#     ICMP error responses reduces log size, although some activity would 
+#     The system must ignore ICMPv4 bogus error responses. Ignoring bogus
+#     ICMP error responses reduces log size, although some activity would
 #     not be logged.
 #
 ############################################################
@@ -34,10 +34,11 @@ sysctl_{{ stig_id }}-noRedirects:
 # This should *NEVER* be needed on a normal system
 create_{{ stig_id }}-{{ checkFile }}:
   file.managed:
-  - name: '{{ checkFile }}'
-  - onlyif: 'test -f {{ checkFile }}'
+    - name: '{{ checkFile }}'
+    - replace: False
+    - onlyif: 'test -f {{ checkFile }}'
 
-# Need to run the next two because security scanners often 
+# Need to run the next two because security scanners often
 # don't understand "secure by default" settings
 comment_{{ stig_id }}-{{ parmName }}:
   file.append:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020840.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020840.sls
@@ -2,15 +2,15 @@
 # Version:	RHEL-07-020840_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	All local initialization files for interactive users must be
 #	owned by the home directory user or root.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-020840' %}
@@ -47,7 +47,8 @@ script_{{ stig_id }}-describe:
 fixown_{{ stig_id }}-{{ user }}-{{ shinitFile }}:
   file.managed:
     - name: '{{ userHome }}/{{ shinitFile }}'
-      user: '{{ user }}'
+    - user: '{{ user }}'
+    - replace: False
       {%- endif  %}
     {%- endfor %}
   {%- endif  %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020850.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020850.sls
@@ -2,15 +2,15 @@
 # Version:	RHEL-07-020850_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	Local initialization files for local interactive users must be
 #	group-owned by the users primary group or root.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-020850' %}
@@ -49,7 +49,8 @@ script_{{ stig_id }}-describe:
 fixown_{{ stig_id }}-{{ user }}-{{ shinitFile }}:
   file.managed:
     - name: '{{ userHome }}/{{ shinitFile }}'
-      group: '{{ userGroup }}'
+    - group: '{{ userGroup }}'
+    - replace: False
       {%- endif  %}
     {%- endfor %}
   {%- endif  %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040060.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040060.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040060_rule
 # SRG ID:	SRG-OS-000068-GPOS-00036
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The cn_map file must have mode 0644 or less permissive.
 #
-# CCI-000187 
-#    NIST SP 800-53 :: IA-5 (2) 
-#    NIST SP 800-53A :: IA-5 (2).1 
-#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c) 
+# CCI-000187
+#    NIST SP 800-53 :: IA-5 (2)
+#    NIST SP 800-53A :: IA-5 (2).1
+#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c)
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040060' %}
@@ -32,6 +32,6 @@ mode_{{ stig_id }}-{{ cfgFile }}:
   file.managed:
     - name: '{{ cfgFile }}'
     - mode: 0644
+    - replace: False
     - require:
       - file: 'touch_{{ stig_id }}-{{ cfgFile }}'
-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040070.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040070.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040070_rule
 # SRG ID:	SRG-OS-000068-GPOS-00036
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The cn_map file must be owned by root.
 #
-# CCI-000187 
-#    NIST SP 800-53 :: IA-5 (2) 
-#    NIST SP 800-53A :: IA-5 (2).1 
-#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c) 
+# CCI-000187
+#    NIST SP 800-53 :: IA-5 (2)
+#    NIST SP 800-53A :: IA-5 (2).1
+#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c)
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040070' %}
@@ -31,6 +31,6 @@ mode_{{ stig_id }}-{{ cfgFile }}:
   file.managed:
     - name: '{{ cfgFile }}'
     - owner: 'root'
+    - replace: False
     - require:
       - file: 'touch_{{ stig_id }}-{{ cfgFile }}'
-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040080.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040080.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040080_rule
 # SRG ID:	SRG-OS-000068-GPOS-00036
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The cn_map file must be group owned by root.
 #
-# CCI-000187 
-#    NIST SP 800-53 :: IA-5 (2) 
-#    NIST SP 800-53A :: IA-5 (2).1 
-#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c) 
+# CCI-000187
+#    NIST SP 800-53 :: IA-5 (2)
+#    NIST SP 800-53A :: IA-5 (2).1
+#    NIST SP 800-53 Revision 4 :: IA-5 (2) (c)
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040080' %}
@@ -31,6 +31,6 @@ mode_{{ stig_id }}-{{ cfgFile }}:
   file.managed:
     - name: '{{ cfgFile }}'
     - group: 'root'
+    - replace: False
     - require:
       - file: 'touch_{{ stig_id }}-{{ cfgFile }}'
-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040640.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040640.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040640_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH public host key files must have mode 0644 or less permissive.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040640' %}
@@ -26,4 +26,5 @@ file_{{ stig_id }}-{{ key }}:
   file.managed:
     - name: '{{ key }}'
     - mode: '0644'
+    - replace: False
 {%- endfor %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040650.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040650.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040650_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH private host key files must have mode 0600 or less permissive.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040650' %}
@@ -26,4 +26,5 @@ file_{{ stig_id }}-{{ key }}:
   file.managed:
     - name: '{{ key }}'
     - mode: '0600'
+    - replace: False
 {%- endfor %}


### PR DESCRIPTION
Avoids spurious warning messages of the form:

```
[WARNING ] State for file: <file> - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```