### PR TITLE
Adds a custom module to list shadow users and uses that rather than `user.list_users`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,12 @@ install:
       $(<${TRAVIS_BUILD_DIR}/tests/requirements.txt) \
       $(<${TRAVIS_BUILD_DIR}/tests/requirements-el${OS_VERSION}.txt)
   - sudo docker exec centos-${OS_VERSION} salt-call --versions-report
+  - |
+    sudo docker exec centos-${OS_VERSION} salt-call --local \
+      --retcode-passthrough \
+      --file-root=$TRAVIS_BUILD_DIR \
+      --pillar-root=$SALT_PILLARROOT \
+      saltutil.sync_all
 
 script:
   - |

--- a/_modules/ash_linux.py
+++ b/_modules/ash_linux.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+Provide custom modules for ash-linux.
+
+:maintainer: Loren Gordon <loren.gordon@plus3it.com>
+"""
+import spwd
+
+__virtualname__ = 'ash'
+
+
+def __virtual__():
+    if __grains__.get('kernel', '') == 'Linux':
+        return __virtualname__
+    else:
+        return False, 'ash_linux module works only on linux systems'
+
+
+def shadow_list_users():
+    """
+    Return a list of all shadow users.
+
+    Will be superseded by ``shadow.list_users``, in the salt Oxygen release.
+
+    CLI Example:
+    .. code-block:: bash
+        salt '*' ash.shadow_list_users
+    """
+    return sorted([user.sp_nam for user in spwd.getspall()])

--- a/ash-linux/el6/STIGbyID/cat1/V38491.sls
+++ b/ash-linux/el6/STIGbyID/cat1/V38491.sls
@@ -29,7 +29,7 @@ file_{{ stigId }}-hostsEquiv:
 {%- endif %}
 
 # Iterate locally-managed users to look for .rhosts files
-{%- for userName in salt['user.list_users']() %}
+{%- for userName in salt['ash.shadow_list_users']() %}
 {%- set userInfo = salt['user.info'](userName) %}
 {%- set userHome = userInfo['home'] %}
 {%- set userRhost = userHome + '/.rhosts' %}

--- a/ash-linux/el6/STIGbyID/cat2/V38496.sls
+++ b/ash-linux/el6/STIGbyID/cat2/V38496.sls
@@ -3,8 +3,8 @@
 # Version:	RHEL-06-000029
 # Finding Level:	Medium
 #
-#     Default operating system accounts, other than root, must be locked. 
-#     Disabling authentication for default system accounts makes it more 
+#     Default operating system accounts, other than root, must be locked.
+#     Disabling authentication for default system accounts makes it more
 #     difficult for attackers to make use of them to compromise a system.
 #
 #  CCI: CCI-000366
@@ -26,7 +26,7 @@ notify_{{ stigId }}-userScan:
   cmd.run:
     - name: 'printf "Scanning locally-managed users:\n\t* Examing users with uid 0 >< 500\n\t* Looking for set or null passwords\n"'
 
-{%- set userList = salt['user.list_users']() %}
+{%- set userList = salt['ash.shadow_list_users']() %}
 {%- for userName in userList %}
 {%- set userInfo =  salt['user.info'](userName) %}
 {%- set userShadow =  salt['shadow.info'](userName) %}


### PR DESCRIPTION
`user.list_users` will return every ldap-/pam-sourced user, which is the expected behavior of the underlying `pwd` library, but it was not the original intention of these states.

This patch uses the `spwd` library to get a list of shadow users, which better scopes the returned value.