### PR TITLE
Issue 229

### DIFF
--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -34,9 +34,9 @@
 {%- set stig_id = 'RHEL-07-021350' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
 {%- set fipsMode = salt.grains.get('ash-linux:lookup:fips-state') | default(
-	salt.pillar.get('ash-linux:lookup:fips-state') | default(
-		'enabled',true),
-	true) %}
+        salt.pillar.get('ash-linux:lookup:fips-state') | default(
+            'enabled',true),
+        true) %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -33,8 +33,10 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-021350' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
-{%- set fipsMode = 'disabled' if salt['pillar.get']('ash-linux:lookup:fips-disabled')| to_bool else 'enabled' %}
-{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled')| to_bool else fipsMode %}
+{%- set fipsMode = salt.grains.get('ash-linux:lookup:fips-state') | default(
+	salt.pillar.get('ash-linux:lookup:fips-state') | default(
+		'enabled',true),
+	true) %}
 
 script_{{ stig_id }}-describe:
   cmd.script:
@@ -43,4 +45,4 @@ script_{{ stig_id }}-describe:
 
 fips_state-{{ stig_id }}:
   ash.fips_state:
-    - value: {{ fipsMode }}
+    - value: {{ fipsMode | string | lower }}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -1,0 +1,51 @@
+# Vuln ID:	V-38653
+# STIG ID:	RHEL-07-040500
+# Rule ID:      SV-86691r2_rule
+# SRG ID(s):    SRG-OS-000033-GPOS-00014
+#               SRG-OS-000185-GPOS-00079
+#               SRG-OS-000396-GPOS-00176
+#               SRG-OS-000405-GPOS-00184
+#               SRG-OS-000478-GPOS-00223
+# Finding Level:        high
+#
+# Rule Summary:
+#       The operating system must implement NIST FIPS-validated
+#       cryptography for the following: to provision digital
+#       signatures, to generate cryptographic hashes, and to
+#       protect data requiring data-at-rest protections in
+#       accordance with applicable federal laws, Executive
+#       Orders, directives, policies, regulations, and
+#       standards.
+#
+# CCI-000068 
+#    NIST SP 800-53 :: AC-17 (2) 
+#    NIST SP 800-53A :: AC-17 (2).1 
+#    NIST SP 800-53 Revision 4 :: AC-17 (2) 
+# CCI-001199
+#    NIST SP 800-53 :: SC-28 
+#    NIST SP 800-53A :: SC-28.1 
+#    NIST SP 800-53 Revision 4 :: SC-28 
+# CCI-002450 
+#    NIST SP 800-53 Revision 4 :: SC-13
+# CCI-002476
+#    NIST SP 800-53 Revision 4 :: SC-28 (1)
+#
+#################################################################
+{%- set stig_id = 'RHEL-07-021350' %}
+{%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
+{%- set fipsMode = 'enabled' if salt['pillar.get']('ash-linux:lookup:fips-enabled') else 'disabled' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+notify_{{ stig_id }}-fipsMode:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Target FIPS-mode is \"{{ fipsMode }}\".''\n"'
+    - cwd: /root
+    - stateful: True
+
+fips_state-{{ stig_id }}:
+  ash.fips_state:
+    - value: {{ fipsMode }}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -34,7 +34,7 @@
 {%- set stig_id = 'RHEL-07-021350' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
 {%- set fipsMode = 'disabled' if salt['pillar.get']('ash-linux:lookup:fips-disabled')| to_bool else 'enabled' %}
-{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled')| to_bool else 'enabled' %}
+{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled')| to_bool else fipsMode %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -41,12 +41,6 @@ script_{{ stig_id }}-describe:
     - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
     - cwd: /root
 
-notify_{{ stig_id }}-fipsMode:
-  cmd.run:
-    - name: 'printf "\nchanged=no comment=''Target FIPS-mode is \"{{ fipsMode }}\".''\n"'
-    - cwd: /root
-    - stateful: True
-
 fips_state-{{ stig_id }}:
   ash.fips_state:
     - value: {{ fipsMode }}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -33,7 +33,8 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-021350' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
-{%- set fipsMode = 'enabled' if salt['pillar.get']('ash-linux:lookup:fips-enabled') else 'disabled' %}
+{%- set fipsMode = 'disabled' if salt['pillar.get']('ash-linux:lookup:fips-disabled') else 'enabled' %}
+{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled') else 'enabled' %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-021350.sls
@@ -33,8 +33,8 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-021350' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
-{%- set fipsMode = 'disabled' if salt['pillar.get']('ash-linux:lookup:fips-disabled') else 'enabled' %}
-{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled') else 'enabled' %}
+{%- set fipsMode = 'disabled' if salt['pillar.get']('ash-linux:lookup:fips-disabled')| to_bool else 'enabled' %}
+{%- set fipsMode = 'disabled' if salt['grains.get']('ash-linux:lookup:fips-disabled')| to_bool else 'enabled' %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat1/files/RHEL-07-021350.sh
+++ b/ash-linux/el7/STIGbyID/cat1/files/RHEL-07-021350.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Vuln ID:	V-38653
+# STIG ID:	RHEL-07-040500
+# Rule ID:      SV-86691r2_rule
+# SRG ID(s):    SRG-OS-000033-GPOS-00014
+#               SRG-OS-000185-GPOS-00079
+#               SRG-OS-000396-GPOS-00176
+#               SRG-OS-000405-GPOS-00184
+#               SRG-OS-000478-GPOS-00223
+# Finding Level:        high
+#
+# Rule Summary:
+#       The operating system must implement NIST FIPS-validated
+#       cryptography for the following: to provision digital
+#       signatures, to generate cryptographic hashes, and to
+#       protect data requiring data-at-rest protections in
+#       accordance with applicable federal laws, Executive
+#       Orders, directives, policies, regulations, and
+#       standards.
+#
+# CCI-000068 
+#    NIST SP 800-53 :: AC-17 (2) 
+#    NIST SP 800-53A :: AC-17 (2).1 
+#    NIST SP 800-53 Revision 4 :: AC-17 (2) 
+# CCI-001199
+#    NIST SP 800-53 :: SC-28 
+#    NIST SP 800-53A :: SC-28.1 
+#    NIST SP 800-53 Revision 4 :: SC-28 
+# CCI-002450 
+#    NIST SP 800-53 Revision 4 :: SC-13
+# CCI-002476
+#    NIST SP 800-53 Revision 4 :: SC-28 (1)
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: RHEL-07-021350"
+diag_out "   Configure the operating system to"
+diag_out "   implement DoD-approved encryption by"
+diag_out "   installing the dracut-fips package."
+diag_out "----------------------------------------"


### PR DESCRIPTION
Adds FIPS selectability via pillar/grain setting of `ash-linux:lookup:fips-disabled`.

Tested setting of grain and pillar to:
- `False`
- `'False'`
- `0`
- `'0'`
- `True`
- `'True'`
- `1`
- `'1'`
- null/undefined
- `<arbitrary string>`
- `'<arbitrary string>'`
All but `True`/`'True'`/`1`/`'1'` result in FIPS mode being enabled or left enabled

Tested that grain-value always supersedes pillar-value.

Closes #229 

Note: The new state — `ash-linux.el7.STIGbyID.cat1.RHEL-07-021350` — has not been added to any top-level run-descriptions. It will need to be added to one/some as appropriate.