### PR TITLE
Does not _require_ a space in the match pattern

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040110.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040110.sls
@@ -2,23 +2,23 @@
 # Version:	RHEL-07-040110_rule
 # SRG ID:	SRG-OS-000033-GPOS-00014
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	A FIPS 140-2 approved cryptographic algorithm must be used for
 #	SSH communications.
 #
-# CCI-000068 
-# CCI-000366 
-# CCI-000803 
-#    NIST SP 800-53 :: AC-17 (2) 
-#    NIST SP 800-53A :: AC-17 (2).1 
-#    NIST SP 800-53 Revision 4 :: AC-17 (2) 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
-#    NIST SP 800-53 :: IA-7 
-#    NIST SP 800-53A :: IA-7.1 
-#    NIST SP 800-53 Revision 4 :: IA-7 
+# CCI-000068
+# CCI-000366
+# CCI-000803
+#    NIST SP 800-53 :: AC-17 (2)
+#    NIST SP 800-53A :: AC-17 (2).1
+#    NIST SP 800-53 Revision 4 :: AC-17 (2)
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
+#    NIST SP 800-53 :: IA-7
+#    NIST SP 800-53A :: IA-7.1
+#    NIST SP 800-53 Revision 4 :: IA-7
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040110' %}
@@ -36,7 +36,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }}.*$'
+    - pattern: '^\s*{{ parmName }}.*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040170.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040170.sls
@@ -2,40 +2,40 @@
 # Version:	RHEL-07-040170_rule
 # SRG ID:	SRG-OS-000023-GPOS-00006
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The Standard Mandatory DoD Notice and Consent Banner must be
 #	displayed immediately prior to, or as part of, remote access
 #	logon prompts.
 #
-# CCI-000048 
-# CCI-000050 
-# CCI-001384 
-# CCI-001385 
-# CCI-001386 
-# CCI-001387 
-# CCI-001388 
-#    NIST SP 800-53 :: AC-8 a 
-#    NIST SP 800-53A :: AC-8.1 (ii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 a 
-#    NIST SP 800-53 :: AC-8 b 
-#    NIST SP 800-53A :: AC-8.1 (iii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 b 
-#    NIST SP 800-53 :: AC-8 c 
-#    NIST SP 800-53A :: AC-8.2 (i) 
-#    NIST SP 800-53 Revision 4 :: AC-8 c 1 
-#    NIST SP 800-53 :: AC-8 c 
-#    NIST SP 800-53A :: AC-8.2 (ii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 c 2 
-#    NIST SP 800-53 :: AC-8 c 
-#    NIST SP 800-53A :: AC-8.2 (ii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 c 2 
-#    NIST SP 800-53 :: AC-8 c 
-#    NIST SP 800-53A :: AC-8.2 (ii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 c 2 
-#    NIST SP 800-53 :: AC-8 c 
-#    NIST SP 800-53A :: AC-8.2 (iii) 
-#    NIST SP 800-53 Revision 4 :: AC-8 c 3 
+# CCI-000048
+# CCI-000050
+# CCI-001384
+# CCI-001385
+# CCI-001386
+# CCI-001387
+# CCI-001388
+#    NIST SP 800-53 :: AC-8 a
+#    NIST SP 800-53A :: AC-8.1 (ii)
+#    NIST SP 800-53 Revision 4 :: AC-8 a
+#    NIST SP 800-53 :: AC-8 b
+#    NIST SP 800-53A :: AC-8.1 (iii)
+#    NIST SP 800-53 Revision 4 :: AC-8 b
+#    NIST SP 800-53 :: AC-8 c
+#    NIST SP 800-53A :: AC-8.2 (i)
+#    NIST SP 800-53 Revision 4 :: AC-8 c 1
+#    NIST SP 800-53 :: AC-8 c
+#    NIST SP 800-53A :: AC-8.2 (ii)
+#    NIST SP 800-53 Revision 4 :: AC-8 c 2
+#    NIST SP 800-53 :: AC-8 c
+#    NIST SP 800-53A :: AC-8.2 (ii)
+#    NIST SP 800-53 Revision 4 :: AC-8 c 2
+#    NIST SP 800-53 :: AC-8 c
+#    NIST SP 800-53A :: AC-8.2 (ii)
+#    NIST SP 800-53 Revision 4 :: AC-8 c 2
+#    NIST SP 800-53 :: AC-8 c
+#    NIST SP 800-53A :: AC-8.2 (iii)
+#    NIST SP 800-53 Revision 4 :: AC-8 c 3
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040170' %}
@@ -61,12 +61,12 @@ file_{{ stig_id }}-{{ parmValu }}:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - not_found_content: |-
         # Inserted per STIG {{ stig_id }}
         {{ parmName }} {{ parmValu }}
-        
+
     - append_if_not_found: True
 
 service_{{ stig_id }}-{{ cfgFile }}:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040191.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040191.sls
@@ -2,17 +2,17 @@
 # Version:	RHEL-07-040191_rule
 # SRG ID:	SRG-OS-000163-GPOS-00072
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	All network connections associated with SSH traffic must
 #	terminate after a period of inactivity.
 #
-# CCI-001133 
-# CCI-002361 
-#    NIST SP 800-53 :: SC-10 
-#    NIST SP 800-53A :: SC-10.1 (ii) 
-#    NIST SP 800-53 Revision 4 :: SC-10 
-#    NIST SP 800-53 Revision 4 :: AC-12 
+# CCI-001133
+# CCI-002361
+#    NIST SP 800-53 :: SC-10
+#    NIST SP 800-53A :: SC-10.1 (ii)
+#    NIST SP 800-53 Revision 4 :: SC-10
+#    NIST SP 800-53 Revision 4 :: AC-12
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040191' %}
@@ -30,7 +30,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040301.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040301.sls
@@ -2,15 +2,15 @@
 # Version:	RHEL-07-040301_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The system must display the date and time of the last
 #	successful account logon upon an SSH logon.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040301' %}
@@ -28,7 +28,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040332.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040332.sls
@@ -2,15 +2,15 @@
 # Version:	RHEL-07-040332_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH daemon must not allow authentication using known
 #	hosts authentication.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040332' %}
@@ -28,7 +28,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040334.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040334.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040334_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH daemon must not allow authentication using rhosts authentication.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040334' %}
@@ -27,7 +27,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040620.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040620.sls
@@ -2,16 +2,16 @@
 # Version:	RHEL-07-040620_rule
 # SRG ID:	SRG-OS-000250-GPOS-00093
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH daemon must be configured to only use Message
 #	Authentication Codes (MACs) employing FIPS 140-2 approved
 #	cryptographic hash algorithms.
 #
-# CCI-001453 
-#    NIST SP 800-53 :: AC-17 (2) 
-#    NIST SP 800-53A :: AC-17 (2).1 
-#    NIST SP 800-53 Revision 4 :: AC-17 (2) 
+# CCI-001453
+#    NIST SP 800-53 :: AC-17 (2)
+#    NIST SP 800-53A :: AC-17 (2).1
+#    NIST SP 800-53 Revision 4 :: AC-17 (2)
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040620' %}
@@ -29,7 +29,7 @@ script_{{ stig_id }}-describe:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040670.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040670.sls
@@ -2,24 +2,24 @@
 # Version:	RHEL-07-040670_rule
 # SRG ID:	SRG-OS-000364-GPOS-00151
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH daemon must not permit Kerberos authentication unless needed.
 #
-# CCI-000368 
-# CCI-000318 
-# CCI-001812 
-# CCI-001813 
-# CCI-001814 
-#    NIST SP 800-53 :: CM-6 c 
-#    NIST SP 800-53A :: CM-6.1 (v) 
-#    NIST SP 800-53 Revision 4 :: CM-6 c 
-#    NIST SP 800-53 :: CM-3 e 
-#    NIST SP 800-53A :: CM-3.1 (v) 
-#    NIST SP 800-53 Revision 4 :: CM-3 f 
-#    NIST SP 800-53 Revision 4 :: CM-11 (2) 
-#    NIST SP 800-53 Revision 4 :: CM-5 (1) 
-#    NIST SP 800-53 Revision 4 :: CM-5 (1) 
+# CCI-000368
+# CCI-000318
+# CCI-001812
+# CCI-001813
+# CCI-001814
+#    NIST SP 800-53 :: CM-6 c
+#    NIST SP 800-53A :: CM-6.1 (v)
+#    NIST SP 800-53 Revision 4 :: CM-6 c
+#    NIST SP 800-53 :: CM-3 e
+#    NIST SP 800-53A :: CM-3.1 (v)
+#    NIST SP 800-53 Revision 4 :: CM-3 f
+#    NIST SP 800-53 Revision 4 :: CM-11 (2)
+#    NIST SP 800-53 Revision 4 :: CM-5 (1)
+#    NIST SP 800-53 Revision 4 :: CM-5 (1)
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040670' %}
@@ -45,7 +45,7 @@ notify_{{ stig_id }}-skipSet:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040690.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040690.sls
@@ -2,14 +2,14 @@
 # Version:	RHEL-07-040690_rule
 # SRG ID:	SRG-OS-000480-GPOS-00227
 # Finding Level:	medium
-# 
+#
 # Rule Summary:
 #	The SSH daemon must use privilege separation.
 #
-# CCI-000366 
-#    NIST SP 800-53 :: CM-6 b 
-#    NIST SP 800-53A :: CM-6.1 (iv) 
-#    NIST SP 800-53 Revision 4 :: CM-6 b 
+# CCI-000366
+#    NIST SP 800-53 :: CM-6 b
+#    NIST SP 800-53A :: CM-6.1 (iv)
+#    NIST SP 800-53 Revision 4 :: CM-6 b
 #
 #################################################################
 {%- set stig_id = 'RHEL-07-040690' %}
@@ -34,7 +34,7 @@ notify_{{ stig_id }}-skipSet:
 file_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: '{{ cfgFile }}'
-    - pattern: '^\s{{ parmName }} .*$'
+    - pattern: '^\s*{{ parmName }} .*$'
     - repl: '{{ parmName }} {{ parmValu }}'
     - append_if_not_found: True
     - not_found_content: |-


### PR DESCRIPTION
Prior pattern was inserting the text even when the option was
present (without a space).

This affects many of the el7 STIG states currently. This patch
only corrects the behavior for /etc/ssh/sshd_config.