### PR TITLE
Add logic to set GRUB2 password

### DIFF
--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
@@ -27,6 +27,8 @@ script_{{ stig_id }}-describe:
     - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
     - cwd: /root
 
+{%- if not salt.file.file_exists(grubFile) %}
+
 user_cfg_permissions-{{ stig_id }}:
   file.managed:
     - name: {{ grubFile }}
@@ -48,3 +50,13 @@ user_cfg_content-{{ stig_id }}:
     - cwd: /root
     - require:
       - file: user_cfg_permissions-{{ stig_id }}
+
+{%- else %}
+
+notify_{{ stig_id }}-noAction:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} skipped due to pre-existence of {{ grubFile }}.''\n"'
+    - stateful: True
+    - cwd: /root
+
+{%- endif %}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
@@ -18,6 +18,7 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-010482' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
+{%- set mustSet = salt.pillar.get('ash-linux:lookup:grub-passwd', '') %}
 {%- set grubPass = salt.pillar.get('ash-linux:lookup:grub-passwd', 'AR34llyB4dP4ssw*rd') %}
 {%- set grubFile = '/boot/grub2/user.cfg' %}
 {%- set grubUtil = '/bin/grub2-mkpasswd-pbkdf2' %}
@@ -27,7 +28,7 @@ script_{{ stig_id }}-describe:
     - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
     - cwd: /root
 
-{%- if not salt.file.file_exists(grubFile) %}
+{%- if ( not mustSet == '' ) or ( not salt.file.file_exists(grubFile) ) %}
 
 user_cfg_permissions-{{ stig_id }}:
   file.managed:

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
@@ -32,17 +32,19 @@ user_cfg_permissions-{{ stig_id }}:
     - name: {{ grubFile }}
     - user: 'root'
     - owner: 'root'
-    - mode: '400'
+    - mode: '000600'
     - replace: false
 
 user_cfg_selLabels-{{ stig_id }}:
   cmd.run:
     - name: 'chcon -u system_u -r object_r -t boot_t {{ grubFile }}'
     - cwd: /root
-    - require: user_cfg_permissions-{{ stig_id }}
+    - require:
+      - file: user_cfg_permissions-{{ stig_id }}
 
 user_cfg_content-{{ stig_id }}:
   cmd.run:
     - name: 'printf "GRUB2_PASSWORD=%s\n" "$( printf "{{ grubPass }}\n{{ grubPass }}\n" | {{ grubUtil }} | awk ''/grub.pbkdf/{print $NF}'' )" > {{ grubFile }}'
     - cwd: /root
-    - require: user_cfg_permissions-{{ stig_id }}
+    - require:
+      - file: user_cfg_permissions-{{ stig_id }}

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
@@ -18,9 +18,9 @@
 #################################################################
 {%- set stig_id = 'RHEL-07-010482' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
+{%- set grubPass = salt.pillar.get('ash-linux:lookup:grub-passwd', 'AR34llyB4dP4ssw*rd') %}
 {%- set grubFile = '/boot/grub2/user.cfg' %}
 {%- set grubUtil = '/bin/grub2-mkpasswd-pbkdf2' %}
-{%- set grubPass = 'AR34llyB4dP4ssw*rd' %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
+++ b/ash-linux/el7/STIGbyID/cat1/RHEL-07-010482.sls
@@ -1,0 +1,48 @@
+# Vuln ID:	V-81005
+# STIG ID:	RHEL-07-010482
+# Rule ID:      SV-95717r1_rule
+# SRG ID(s):    SRG-OS-000080-GPOS-00048
+# Finding Level:        high
+#
+# Rule Summary:
+#       Red Hat Enterprise Linux operating systems version 7.2
+#       or newer with a Basic Input/Output System (BIOS) must
+#       require authentication upon booting into single-user
+#       and maintenance modes.
+#
+# CCI-000213
+#    NIST SP 800-53 :: AC-3
+#    NIST SP 800-53A :: AC-3.1
+#    NIST SP 800-53 Revision 4 :: AC-3
+#
+#################################################################
+{%- set stig_id = 'RHEL-07-010482' %}
+{%- set helperLoc = 'ash-linux/el7/STIGbyID/cat1/files' %}
+{%- set grubFile = '/boot/grub2/user.cfg' %}
+{%- set grubUtil = '/bin/grub2-mkpasswd-pbkdf2' %}
+{%- set grubPass = 'AR34llyB4dP4ssw*rd' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+user_cfg_permissions-{{ stig_id }}:
+  file.managed:
+    - name: {{ grubFile }}
+    - user: 'root'
+    - owner: 'root'
+    - mode: '400'
+    - replace: false
+
+user_cfg_selLabels-{{ stig_id }}:
+  cmd.run:
+    - name: 'chcon -u system_u -r object_r -t boot_t {{ grubFile }}'
+    - cwd: /root
+    - require: user_cfg_permissions-{{ stig_id }}
+
+user_cfg_content-{{ stig_id }}:
+  cmd.run:
+    - name: 'printf "GRUB2_PASSWORD=%s\n" "$( printf "{{ grubPass }}\n{{ grubPass }}\n" | {{ grubUtil }} | awk ''/grub.pbkdf/{print $NF}'' )" > {{ grubFile }}'
+    - cwd: /root
+    - require: user_cfg_permissions-{{ stig_id }}

--- a/ash-linux/el7/STIGbyID/cat1/files/RHEL-07-010482.sh
+++ b/ash-linux/el7/STIGbyID/cat1/files/RHEL-07-010482.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Vuln ID:	V-81005
+# STIG ID:	RHEL-07-010482
+# Rule ID:      SV-95717r1_rule
+# SRG ID(s):    SRG-OS-000080-GPOS-00048
+# Finding Level:        high
+#
+# Rule Summary:
+#       Red Hat Enterprise Linux operating systems version 7.2
+#       or newer with a Basic Input/Output System (BIOS) must
+#       require authentication upon booting into single-user
+#       and maintenance modes.
+#
+# CCI-000213
+#    NIST SP 800-53 :: AC-3
+#    NIST SP 800-53A :: AC-3.1
+#    NIST SP 800-53 Revision 4 :: AC-3
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: RHEL-07-021350"
+diag_out "   Configure the GRUB2 boot-loader to"
+diag_out "   a password to boot into single user"
+diag_out "   or other alternate modes"
+diag_out "----------------------------------------"

--- a/ash-linux/el7/STIGbyID/cat1/init.sls
+++ b/ash-linux/el7/STIGbyID/cat1/init.sls
@@ -8,6 +8,7 @@ include:
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-010440
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-010460
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-010470
+  - ash-linux.el7.STIGbyID.cat1.RHEL-07-010482
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-020000
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-020010
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-020150

--- a/ash-linux/el7/STIGbyID/init.sls
+++ b/ash-linux/el7/STIGbyID/init.sls
@@ -1,9 +1,13 @@
 include:
   - ash-linux.el7.STIGbyID.cat1.RHEL-07-021350
+  - ash-linux.el7.STIGbyID.cat1.RHEL-07-010482
+
 
 Print ash-linux el7 stig baseline help:
   test.show_notification:
     - text: |
-        The full `ash-linux.stig` baseline for EL7 is in beta. This stub will
-        only manage FIPS mode on the system. To apply the full beta STIG,
-        please use the state: `ash-linux.el7.stig`
+        The full, item-by-item `ash-linux.stig` baseline for EL7 is in beta. 
+        This stub will only manage FIPS mode and the GRUB password on the
+        system.
+        
+        To apply the full beta STIG, please use the state: `ash-linux.el7.stig`

--- a/pillar.example
+++ b/pillar.example
@@ -61,7 +61,11 @@
 ##       nameservers
 ##         - nameserver1.I.P.addr
 ##         - nameserver2.I.P.addr
-#
+
+
+##  Set a localized/custom password on the GRUB boot-loader
+##     grub-passwd: <POLICY_COMPLIANT_PASSWORD_STRING>
+
     # If using oscap to harden, which profile to select
     # If unsure of available profiles, use `oscap info \
     # "/usr/share/xml/scap/ssg/content/ssg-${OSVERS}-xccdf.xml"`


### PR DESCRIPTION
Closes #260 

Use logic to _always_ create/overwrite the `/boot/grub2/user.cfg` file if Pillar value is set while only creating if Pillar value is undef/null _and_ `/boot/grub2/user.cfg` file doesn't already exist