### PR TITLE
Add handlers for CIS 5.2.3 that some scanners/profiles check for

### DIFF
--- a/ash-linux/el7/Miscellaneous/CIS-5_2_3.sls
+++ b/ash-linux/el7/Miscellaneous/CIS-5_2_3.sls
@@ -1,0 +1,49 @@
+# Rule Name:    sshd_set_loglevel_info
+# CIS Rule ID:  5.2.3
+#
+# Summary:
+#
+#    SSH provides several logging levels with varying amounts of
+#    verbosity. DEBUG is specifically not recommended other than
+#    strictly for debugging SSH communications since it provides
+#    so much data that it is difficult to identify important
+#    security information. INFO level is the basic level that
+#    only records login activity of SSH users. In many
+#    situations, such as Incident Response, it is important to
+#    determine when a particular user was active on a system. The
+#    logout record can eliminate those users who disconnected,
+#    which helps narrow the field.
+#
+#    Note: The EL7 SSHD defaults the value for the LogLevel 
+#    parameter to be `INFO`. This state is simply designed to
+#    help reduce false alerts caused by scan profiles that fail
+#    to properly identify this defaulted posture.
+#
+#################################################################
+{%- set helperLoc = 'ash-linux/el7/Miscellaneous/files' %}
+{%- set statename = 'CIS-5_2_3' %}
+{%- set svcName = 'sshd' %}
+{%- set cfgFile = '/etc/ssh/sshd_config' %}
+{%- set parmName = 'LogLevel' %}
+{%- set parmValu = salt.pillar.get('ash-linux:lookup:sshd-loglevel', 'INFO') %}
+
+script_{{ statename }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ statename }}.sh
+    - cwd: /root
+
+file_{{ statename }}-{{ cfgFile }}:
+  file.replace:
+    - name: '{{ cfgFile }}'
+    - pattern: '^\s*{{ parmName }} .*$'
+    - repl: '{{ parmName }} {{ parmValu }}'
+    - append_if_not_found: True
+    - not_found_content: |-
+        # Inserted per CIS 5.2.3
+        {{ parmName }} {{ parmValu }}
+
+service_{{ statename }}-{{ cfgFile }}:
+  service.running:
+    - name: '{{ svcName }}'
+    - watch:
+      - file: file_{{ statename }}-{{ cfgFile }}

--- a/ash-linux/el7/Miscellaneous/files/CIS-5_2_3.sh
+++ b/ash-linux/el7/Miscellaneous/files/CIS-5_2_3.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Rule Name:    sshd_set_loglevel_info
+# CIS Rule ID:  5.2.3
+#
+# Summary:
+#
+#    SSH provides several logging levels with varying amounts of
+#    verbosity. DEBUG is specifically not recommended other than
+#    strictly for debugging SSH communications since it provides
+#    so much data that it is difficult to identify important
+#    security information. INFO level is the basic level that
+#    only records login activity of SSH users. In many
+#    situations, such as Incident Response, it is important to
+#    determine when a particular user was active on a system. The
+#    logout record can eliminate those users who disconnected,
+#    which helps narrow the field.
+#
+#    Note: The EL7 SSHD defaults the value for the LogLevel 
+#    parameter to be `Info`. This state is simply designed to
+#    help reduce false alerts caused by scan profiles that fail
+#    to properly identify this defaulted posture.
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "CIS Benchmark ID: 5.2.3"
+diag_out "   Configure SSHD to log all activities"
+diag_out "   at the 'Info' level (minimum)"
+diag_out "----------------------------------------"
+

--- a/ash-linux/el7/VendorSTIG/init.sls
+++ b/ash-linux/el7/VendorSTIG/init.sls
@@ -14,4 +14,5 @@ include:
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010040
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040170
   - ash-linux.el7.Miscellaneous.firewalld_safeties
+  - ash-linux.el7.Miscellaneous.CIS-5_2_3
   - ash-linux.audit_load

--- a/ash-linux/el7/stig.sls
+++ b/ash-linux/el7/stig.sls
@@ -3,4 +3,5 @@ include:
   - ash-linux.el7.STIGbyID.cat2
   - ash-linux.el7.STIGbyID.cat3
   - ash-linux.el7.Miscellaneous.firewalld_safeties
+  - ash-linux.el7.Miscellaneous.CIS-5_2_3
   - ash-linux.audit_load

--- a/pillar.example
+++ b/pillar.example
@@ -66,6 +66,11 @@
 ##  Set a localized/custom password on the GRUB boot-loader
 ##     grub-passwd: <POLICY_COMPLIANT_PASSWORD_STRING>
 
+##  Ensure that the LogLevel parm in sshd_config is set to the
+##  site-mandated value
+##     sshd-loglevel:  <QUIET|FATAL|ERROR|INFO|VERBOSE|DEBUG|DEBUG1|DEBUG2|DEBUG3>
+##  (See man page for valid values and associated output/warnings)
+
     # If using oscap to harden, which profile to select
     # If unsure of available profiles, use `oscap info \
     # "/usr/share/xml/scap/ssg/content/ssg-${OSVERS}-xccdf.xml"`


### PR DESCRIPTION
Probably need to open a BugZilla to get this removed from the C2S profile. At any rate, closes #253 

