### PR TITLE
Add logic for changing grub-user's name

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -64,6 +64,7 @@
 
 
 ##  Set a localized/custom password on the GRUB boot-loader
+##     grub-user: <ANY_STRING_OTHER_THAN_root>
 ##     grub-passwd: <POLICY_COMPLIANT_PASSWORD_STRING>
 
 ##  Ensure that the LogLevel parm in sshd_config is set to the


### PR DESCRIPTION
Closes #265 

Verified: 
- absent Pillar value, default value's get set
- value from Pillar gets set
- file is regenerated upon change of superuser name's value
