### PR TITLE
Ensure a `MaxAuthTries` value is explicitly set 

### DIFF
--- a/ash-linux/el6/SCAPonly/low/CCE-26340-0.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26340-0.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26361-6.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26361-6.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26404-4.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26404-4.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26544-7.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26544-7.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26670-0.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26670-0.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26677-5.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26677-5.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el6/SCAPonly/low/CCE-26800-3.sls
+++ b/ash-linux/el6/SCAPonly/low/CCE-26800-3.sls
@@ -26,7 +26,6 @@ script_{{ scapId }}-describe:
 append_{{ scapId }}-directive:
   file.append:
     - name: '{{ moduleConf }}'
-    - mode: '0644'
     - text: |
         # Added per SCAP-ID {{ scapId }}
         install {{ fsDrv }} /bin/false

--- a/ash-linux/el7/Miscellaneous/CIS-5_2_5.sls
+++ b/ash-linux/el7/Miscellaneous/CIS-5_2_5.sls
@@ -1,0 +1,48 @@
+# Rule Name:    sshd_set_max_auth_tries
+# CIS Rule ID:  5.2.5
+#
+# Summary:
+#
+#    The MaxAuthTries parameter specifies the maximum number of
+#    authentication attempts permitted per connection. When the
+#    login failure count reaches half the number, error messages
+#    will be written to the syslog file detailing the login
+#    failure.
+#
+#    Setting the MaxAuthTries parameter to a low number will
+#    minimize the risk of successful brute force attacks to the
+#    SSH server. While the recommended setting is 4, set the
+#    number based on site policy.
+#
+#    Note: Mostly obviated by the STIG-mandated modifications to
+#    the PAM subsystem. Included for scanners that include CIS-
+#    recommended settings that are not part of the STIGs
+#
+#################################################################
+{%- set helperLoc = 'ash-linux/el7/Miscellaneous/files' %}
+{%- set statename = 'CIS-5_2_5' %}
+{%- set svcName = 'sshd' %}
+{%- set cfgFile = '/etc/ssh/sshd_config' %}
+{%- set parmName = 'MaxAuthTries' %}
+{%- set parmValu = salt.pillar.get('ash-linux:lookup:sshd-maxTries', '4') %}
+
+script_{{ statename }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ statename }}.sh
+    - cwd: /root
+
+file_{{ statename }}-{{ cfgFile }}:
+  file.replace:
+    - name: '{{ cfgFile }}'
+    - pattern: '^\s*{{ parmName }} .*$'
+    - repl: '{{ parmName }} {{ parmValu }}'
+    - append_if_not_found: True
+    - not_found_content: |-
+        # Inserted per CIS 5.2.5
+        {{ parmName }} {{ parmValu }}
+
+service_{{ statename }}-{{ cfgFile }}:
+  service.running:
+    - name: '{{ svcName }}'
+    - watch:
+      - file: file_{{ statename }}-{{ cfgFile }}

--- a/ash-linux/el7/Miscellaneous/files/CIS-5_2_5.sh
+++ b/ash-linux/el7/Miscellaneous/files/CIS-5_2_5.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Rule Name:    sshd_set_max_auth_tries
+# CIS Rule ID:  5.2.5
+#
+# Summary:
+#
+#    The MaxAuthTries parameter specifies the maximum number of
+#    authentication attempts permitted per connection. When the
+#    login failure count reaches half the number, error messages
+#    will be written to the syslog file detailing the login
+#    failure.
+#
+#    Setting the MaxAuthTries parameter to a low number will
+#    minimize the risk of successful brute force attacks to the
+#    SSH server. While the recommended setting is 4, set the
+#    number based on site policy.
+#
+#    Note: Mostly obviated by the STIG-mandated modifications to
+#    the PAM subsystem. Included for scanners that include CIS-
+#    recommended settings that are not part of the STIGs
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "CIS Benchmark ID: 5.2.5"
+diag_out "   Configure SSHD to limit number of"
+diag_out "   failed authentication attempts."
+diag_out "----------------------------------------"
+

--- a/ash-linux/el7/VendorSTIG/init.sls
+++ b/ash-linux/el7/VendorSTIG/init.sls
@@ -15,4 +15,5 @@ include:
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040170
   - ash-linux.el7.Miscellaneous.firewalld_safeties
   - ash-linux.el7.Miscellaneous.CIS-5_2_3
+  - ash-linux.el7.Miscellaneous.CIS-5_2_5
   - ash-linux.audit_load

--- a/ash-linux/el7/stig.sls
+++ b/ash-linux/el7/stig.sls
@@ -4,4 +4,5 @@ include:
   - ash-linux.el7.STIGbyID.cat3
   - ash-linux.el7.Miscellaneous.firewalld_safeties
   - ash-linux.el7.Miscellaneous.CIS-5_2_3
+  - ash-linux.el7.Miscellaneous.CIS-5_2_5
   - ash-linux.audit_load


### PR DESCRIPTION
Closes #270 

Note: for whatever reason, the `OS_VERSION=6 SALT_STATE=ash-linux.scap` is refusing to go green for me. It's not relevant to this change, since it's a change wholly within the EL7 tree, but... May require a force-merge if Travis is going to continue to flake out on it, today.