### PR TITLE
Set permissions so systemd stops its whining

### DIFF
--- a/ash-linux/el7/VendorSTIG/cat3/mount_options_tmp.sls
+++ b/ash-linux/el7/VendorSTIG/cat3/mount_options_tmp.sls
@@ -45,9 +45,9 @@ file_{{ stig_id }}-{{ targMnt }}:
     - name: '{{ optionsFile }}'
     - user: 'root'
     - grou: 'root'
-    - mode: '0600'
+    - mode: '0644'
     - makedirs: True
-    - dir_mode: '0700'
+    - dir_mode: '0755'
     - contents: |-
         [Mount]
         Options=mode=1777,strictatime,{{ mntOpt|join(",") }}


### PR DESCRIPTION
Did a quick `find` in the `ash-linux/el7` tree for files referencing systemd. Only found the one (related to the `tmp.mount` service) that actually exerted ownership on a `systemd` unit- or configuration-file. Fixed that state-file (closes #280).


