### PR TITLE
Enables FIPS in AIDE rules

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-021620.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-021620.sls
@@ -33,3 +33,9 @@ fixcfg_{{ stig_id }}-{{ cfgFile }}:
              else print $0}'' {{ cfgFile }} > /tmp/{{ stig_id }} && mv
              /tmp/{{ stig_id }} {{ cfgFile }}'
     - cwd: /root
+
+setDefault_{{ stig_id }}-{{ cfgFile }}:
+  file.replace:
+    - name: {{ cfgFile }}
+    - pattern: '^\s*NORMAL\s*=\s*.*$'
+    - repl: 'NORMAL = FIPSR+sha512'

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-021620.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-021620.sls
@@ -33,9 +33,13 @@ fixcfg_{{ stig_id }}-{{ cfgFile }}:
              else print $0}'' {{ cfgFile }} > /tmp/{{ stig_id }} && mv
              /tmp/{{ stig_id }} {{ cfgFile }}'
     - cwd: /root
+    - require:
+      - pkg: 'pkg_{{ stig_id }}-aide'
 
 setDefault_{{ stig_id }}-{{ cfgFile }}:
   file.replace:
     - name: {{ cfgFile }}
     - pattern: '^\s*NORMAL\s*=\s*.*$'
     - repl: 'NORMAL = FIPSR+sha512'
+    - require:
+      - cmd: 'fixcfg_{{ stig_id }}-{{ cfgFile }}'

--- a/ash-linux/el7/STIGbyID/init.sls
+++ b/ash-linux/el7/STIGbyID/init.sls
@@ -4,6 +4,7 @@ include:
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040110
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040350
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-040400
+  - ash-linux.el7.STIGbyID.cat2.RHEL-07-021620
 
 
 


### PR DESCRIPTION
Closes #284 

Note: even applying this fix, OpenSCAP scan with "stig" profile seems to not properly identify that the prescribed fix-text is present in `/etc/aide.conf`. Will need to see if other scanners also have this error (and update "known findings" documentation).