### PR TITLE
Change service.running file-check directive from 'watch' to 'listen'

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040660.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040660.sls
@@ -57,6 +57,6 @@ file_{{ stig_id }}-{{ cfgFile }}:
 service_{{ stig_id }}-{{ cfgFile }}:
   service.running:
     - name: '{{ svcName }}' 
-    - watch:
+    - listen:
       - file: file_{{ stig_id }}-{{ cfgFile }}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040670.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040670.sls
@@ -55,6 +55,6 @@ file_{{ stig_id }}-{{ cfgFile }}:
 service_{{ stig_id }}-{{ cfgFile }}:
   service.running:
     - name: '{{ svcName }}'
-    - watch:
+    - listen:
       - file: file_{{ stig_id }}-{{ cfgFile }}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040680.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040680.sls
@@ -46,6 +46,6 @@ file_{{ stig_id }}-{{ cfgFile }}:
 service_{{ stig_id }}-{{ cfgFile }}:
   service.running:
     - name: '{{ svcName }}'
-    - watch:
+    - listen:
       - file: file_{{ stig_id }}-{{ cfgFile }}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040690.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040690.sls
@@ -44,6 +44,6 @@ file_{{ stig_id }}-{{ cfgFile }}:
 service_{{ stig_id }}-{{ cfgFile }}:
   service.running:
     - name: '{{ svcName }}'
-    - watch:
+    - listen:
       - file: file_{{ stig_id }}-{{ cfgFile }}
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040700.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040700.sls
@@ -46,6 +46,6 @@ file_{{ stig_id }}-{{ cfgFile }}:
 service_{{ stig_id }}-{{ cfgFile }}:
   service.running:
     - name: '{{ svcName }}'
-    - watch:
+    - listen:
       - file: file_{{ stig_id }}-{{ cfgFile }}
 {%- endif %}


### PR DESCRIPTION
Addresses problems with too-quickly consecutively-restarting `sshd.service` (closes #297 )