### PR TITLE
Closes #317

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040810.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040810.sls
@@ -36,7 +36,7 @@ service_{{ stig_id }}-dead:
 # Remove iptables.service if present
 package_{{ stig_id }}-absent:
   pkg.removed:
-    - name: iptables
+    - name: iptables-services
 
 # Install firewalld if absent
 package_{{ stig_id }}-present:


### PR DESCRIPTION
Only want to remove the `iptables-services` RPM, not the underlying, core-package `iptables` RPM  (which has a LOT of dependencies that  we DON'T want removed)