### PR TITLE
Update method to match STIGv2 (and later) requirements

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-010270.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-010270.sls
@@ -43,7 +43,7 @@ file-add_{{ stig_id }}-{{ targFile }}:
     - pattern: '^(?P<srctok>(|\s*)password\s*sufficient\s*pam_unix.so.*$)'
     - repl: '\g<srctok>\npassword    requisite     pam_pwhistory.so use_authtok remember=5 retry=3'
     - unless:
-      - 'grep -P "^(|\s*)password\s*requisite \s*pam_pwhistory.so.*$" {{ targFile }}'
+      - 'grep -P "^(|\s*)password\s*requisite\s*pam_pwhistory.so.*$" {{ targFile }}'
 file-modify_{{ stig_id }}-{{ targFile }}:
   file.replace:
     - name: {{ targFile }}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-010270.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-010270.sls
@@ -16,11 +16,10 @@
 {%- set stig_id = 'RHEL-07-010270' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
-{%- set targFile = '/etc/pam.d/system-auth' %}
-{%- if salt.file.is_link(targFile) %}
-  {%- set targFile = targFile + '-ac' %}
-{%- endif %}
-{%- set searchRoot = '^password\s+sufficient\s+pam_unix.so\s+' %}
+{%- set targFileList = [
+    '/etc/pam.d/system-auth',
+    '/etc/pam.d/password-auth',
+] %}
 
 script_{{ stig_id }}-describe:
   cmd.script:
@@ -34,31 +33,23 @@ notify_{{ stig_id }}-skipSet:
     - stateful: True
     - cwd: /root
 {%- else %}
-  {%- if salt.file.search(targFile, searchRoot + '.*remember=5') %}
-file_{{ stig_id }}-{{ targFile }}:
-  cmd.run:
-    - name: 'printf "\nchanged=no comment=''Found target config in {{ targFile }}.''\n"'
-    - cwd: /root
-    - stateful: True
-  {%- elif salt.file.search(targFile, searchRoot) %}
-file_{{ stig_id }}-{{ targFile }}:
+  {%- for targFile in targFileList %}
+    {%- if salt.file.is_link(targFile) %}
+      {%- set targFile = targFile + '-ac' %}
+    {%- endif %}
+file-add_{{ stig_id }}-{{ targFile }}:
   file.replace:
     - name: {{ targFile }}
-    - pattern: '^(?P<srctok>{{ searchRoot }}.*$)'
-    - repl: '\g<srctok> remember=5'
-file_{{ stig_id }}-{{ targFile }}-cleanup:
+    - pattern: '^(?P<srctok>(|\s*)password\s*sufficient\s*pam_unix.so.*$)'
+    - repl: '\g<srctok>\npassword    requisite     pam_pwhistory.so use_authtok remember=5 retry=3'
+    - unless:
+      - 'grep -P "^(|\s*)password\s*requisite \s*pam_pwhistory.so.*$" {{ targFile }}'
+file-modify_{{ stig_id }}-{{ targFile }}:
   file.replace:
     - name: {{ targFile }}
-    - pattern: '(md5|bigcrypt|sha256|blowfish) '
-    - repl: ''
-    - onchanges:
-      - file: file_{{ stig_id }}-{{ targFile }}
-  {%- else %}
-file_{{ stig_id }}-{{ targFile }}:
-  file.replace:
-    - name: {{ targFile }}
-    - pattern: '^(?P<srctok>^password\s+requisite\s+pam_pwquality.so.*)'
-    - repl: '\g<srctok>\npassword sufficient pam_unix.so remember=5'
-  {%- endif %}
+    - pattern: '^(|\s*)(password\s*sufficient\s*pam_pwhistory.so)(.*)'
+    - repl: 'password    requisite     pam_pwhistory.so use_authtok remember=5 retry=3'
+    - onlyif:
+      - 'grep -P "^(|\s*)password\s*requisite\s*pam_pwhistory.so.*$" {{ targFile }}'
+  {%- endfor %}
 {%- endif %}
-


### PR DESCRIPTION
Closes #343 

Method was updated with the v2r1 STIG-release for EL7. Have updated the previous content's handler to use the updated method. When the state runs:

* The line will be added if absent:

```
# salt-call -c /opt/watchmaker/salt state.apply ash-linux.el7.STIGbyID.cat2.RHEL-07-010270
salt/utils/files.py:385: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
local:
----------
          ID: file-add_RHEL-07-010270-/etc/pam.d/system-auth
    Function: file.replace
        Name: /etc/pam.d/system-auth
      Result: True
     Comment: Changes were made
     Started: 17:25:48.235672
    Duration: 3729.584 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -21,6 +21,7 @@

                   password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
                   password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok
                  +password    sufficient    pam_pwhistory.so remember=5
                   password    sufficient    pam_sss.so use_authtok
                   password    required      pam_deny.so

----------
          ID: file-modify_RHEL-07-010270-/etc/pam.d/system-auth
    Function: file.replace
        Name: /etc/pam.d/system-auth
      Result: True
     Comment: No changes needed to be made
     Started: 17:25:51.965509
    Duration: 15.122 ms
     Changes:
----------
          ID: file-add_RHEL-07-010270-/etc/pam.d/password-auth
    Function: file.replace
        Name: /etc/pam.d/password-auth
      Result: True
     Comment: Changes were made
     Started: 17:25:51.980885
    Duration: 15.559 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -20,6 +20,7 @@

                   password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
                   password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok
                  +password    sufficient    pam_pwhistory.so remember=5
                   password    sufficient    pam_sss.so use_authtok

                   auth        required      pam_faillock.so authfail deny=3 even_deny_root fail_interval=900 unlock_time=0
----------
          ID: file-modify_RHEL-07-010270-/etc/pam.d/password-auth
    Function: file.replace
        Name: /etc/pam.d/password-auth
      Result: True
     Comment: No changes needed to be made
     Started: 17:25:51.996682
    Duration: 14.258 ms
     Changes:

Summary for local
------------
Succeeded: 4 (changed=2)
Failed:    0
------------
Total states run:     4
Total run time:   3.775 s
```

* The line will be modified if present but not correct:
```

# salt-call -c /opt/watchmaker/salt state.apply ash-linux.el7.STIGbyID.cat2.RHEL-07-010270
  f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
local:
----------
          ID: file-add_RHEL-07-010270-/etc/pam.d/system-auth
    Function: file.replace
        Name: /etc/pam.d/system-auth
      Result: True
     Comment: unless condition is true
     Started: 17:47:08.419647
    Duration: 3756.787 ms
     Changes:
----------
          ID: file-modify_RHEL-07-010270-/etc/pam.d/system-auth
    Function: file.replace
        Name: /etc/pam.d/system-auth
      Result: True
     Comment: Changes were made
     Started: 17:47:12.176797
    Duration: 17.651 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -21,7 +21,7 @@

                   password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
                   password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok
                  -password    sufficient    pam_pwhistory.so use_authtok remember=7 retry=3
                  +password    sufficient    pam_pwhistory.so use_authtok remember=5 retry=3
                   password    sufficient    pam_sss.so use_authtok
                   password    required      pam_deny.so

----------
          ID: file-add_RHEL-07-010270-/etc/pam.d/password-auth
    Function: file.replace
        Name: /etc/pam.d/password-auth
      Result: True
     Comment: unless condition is true
     Started: 17:47:12.194697
    Duration: 12.645 ms
     Changes:
----------
          ID: file-modify_RHEL-07-010270-/etc/pam.d/password-auth
    Function: file.replace
        Name: /etc/pam.d/password-auth
      Result: True
     Comment: Changes were made
     Started: 17:47:12.207708
    Duration: 15.641 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -20,7 +20,7 @@

                   password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
                   password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok
                  -password    sufficient    pam_pwhistory.so use_authtok remember=7 retry=3
                  +password    sufficient    pam_pwhistory.so use_authtok remember=5 retry=3
                   password    sufficient    pam_sss.so use_authtok

                   auth        required      pam_faillock.so authfail deny=3 even_deny_root fail_interval=900 unlock_time=0

Summary for local
------------
Succeeded: 4 (changed=2)
Failed:    0
------------
Total states run:     4
Total run time:   3.803 s
```