### PR TITLE
Fix Ciphers parameter's list-order

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-040110.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-040110.sls
@@ -28,7 +28,7 @@
 {%- set svcName = 'sshd' %}
 {%- set cfgFile = '/etc/ssh/sshd_config' %}
 {%- set parmName = 'Ciphers' %}
-{%- set parmValu = 'aes128-ctr,aes192-ctr,aes256-ctr' %}
+{%- set parmValu = 'aes256-ctr,aes192-ctr,aes128-ctr' %}
 
 script_{{ stig_id }}-describe:
   cmd.script:


### PR DESCRIPTION
More-recent STIGs specify a different list-order for the `/etc/ssh/sshd_config` file's `Ciphers` parameter-value. This update ensures compliance-correctness up through STIGv3r6

Closes #350 