### PR TITLE
Fix overlooked missing close-quote

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-010671.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-010671.sh
@@ -27,5 +27,5 @@ diag_out() {
 diag_out "--------------------------------------"
 diag_out "STIG Finding ID: V-230311"
 diag_out "     The OS must disable the"
-diag_out "     `kernel.core_pattern` setting"
+diag_out "     kernel.core_pattern setting"
 diag_out "--------------------------------------"

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020021.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020021.sh
@@ -28,5 +28,5 @@ diag_out() {
 diag_out "--------------------------------------"
 diag_out "STIG Finding ID: V-230343"
 diag_out "     User names must be logged on"
-diag_out "     failed login attempts
+diag_out "     failed login attempts"
 diag_out "--------------------------------------"


### PR DESCRIPTION
Discovered previously-missed error in two of the `…/STIGbyID/cat2/files` scripts.