### PR TITLE
Addresses V-230364: Set each user's minimum password-age policy-value

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020180.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020180.sls
@@ -1,0 +1,46 @@
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230364
+# Rule ID:    SV-230364r627750_rule
+# STIG ID:    RHEL-08-020180
+# SRG ID:     SRG-OS-000075-GPOS-00043
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       Passwords managed by the operating system  must have a 24 hours/1
+#       day minimum password lifetime restriction in /etc/shadow.
+#
+# References:
+#   CCI:
+#     - CCI-000198
+#   NIST SP 800-53 :: IA-5 (1) (d)
+#   NIST SP 800-53A :: IA-5 (1).1 (v)
+#   NIST SP 800-53 Revision 4 :: IA-5 (1) (d)
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-020180' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set userList =  salt.user.list_users() %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+  {%- for user in userList %}
+Set minimum password lifetime for {{ user }}:
+  user.present:
+    - name: '{{ user }}'
+    - mindays: 1
+    - onlyif:
+      - '[[ -n $( awk -F: ''/{{ user }}:/ && $4 < 1  {print $1 " " $4}'' /etc/shadow ) ]]'
+  {%- endfor %}
+{%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020180.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020180.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230364
+# Rule ID:    SV-230364r627750_rule
+# STIG ID:    RHEL-08-020180
+# SRG ID:     SRG-OS-000075-GPOS-00043
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       Passwords managed by the operating system  must have a 24 hours/1
+#       day minimum password lifetime restriction in /etc/shadow.
+#
+# References:
+#   CCI:
+#     - CCI-000198
+#   NIST SP 800-53 :: IA-5 (1) (d)
+#   NIST SP 800-53A :: IA-5 (1).1 (v)
+#   NIST SP 800-53 Revision 4 :: IA-5 (1) (d)
+#
+###########################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "--------------------------------------"
+diag_out "STIG Finding ID: V-230364"
+diag_out "     OS-/locally-managed passwords may"
+diag_out "     not be changed more than once per"
+diag_out "     twenty-four hours"
+diag_out "--------------------------------------"

--- a/ash-linux/el8/STIGbyID/cat2/init.sls
+++ b/ash-linux/el8/STIGbyID/cat2/init.sls
@@ -15,6 +15,7 @@ include:
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020021
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020041
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020090
+  - ash-linux.el8.STIGbyID.cat2.RHEL-08-020180
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020220
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020221
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-030740


### PR DESCRIPTION
Sets minimum password age of "1" for every enumerated user that has either a null or sub-`1` value for field number 4 in /etc/shadow.

Closes #367 