### PR TITLE
Ensure that OS restricts usage of ptrace to descendant  processes

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
@@ -1,0 +1,55 @@
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230546
+# Rule ID:    SV-230546r858824_rule
+# STIG ID:    RHEL-08-040282
+# SRG ID:     SRG-OS-000480-GPOS-00227
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       RHEL 8 SRG-OS-000480-GPOS-00227
+#
+# References:
+#   CCI:
+#     - CCI-000366
+#   NIST SP 800-53 :: CM-6 b
+#   NIST SP 800-53A :: CM-6.1 (iv)
+#   NIST SP 800-53 Revision 4 :: CM-6 b
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-040282' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set searchDirs =[
+  '/etc/sysctl.d/',
+  '/lib/sysctl.d/',
+  '/run/sysctl.d',
+  '/usr/lib/sysctl.d',
+  '/usr/local/lib/sysctl.d',
+] %}
+{%- set sysctlFiles = [ '/etc/sysctl.conf' ] %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+    - stateful: True
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+  {%- for searchDir in searchDirs %}
+    {%- do sysctlFiles.extend(salt.file.find(searchDir, type='f', name='*.conf', grep='kernel\.yama\.ptrace_scope')) %}
+  {%- endfor %}
+  {%- for sysctlFile in sysctlFiles %}
+Fix kernel.yama\.ptrace_scope in {{ sysctlFile }}:
+  file.replace:
+    - name: '{{ sysctlFile }}'
+    - pattern: '^(\s*|#(\s*|))(kernel\.yama\.ptrace_scope)(\s*=\s*).*$'
+    - repl: '\3\4|/bin/false'
+  {%- endfor %}
+{%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
@@ -50,6 +50,6 @@ Fix kernel.yama\.ptrace_scope in {{ sysctlFile }}:
   file.replace:
     - name: '{{ sysctlFile }}'
     - pattern: '^(\s*|#(\s*|))(kernel\.yama\.ptrace_scope)(\s*=\s*).*$'
-    - repl: '\3\4|/bin/false'
+    - repl: '\g<3>\g<4>1'
   {%- endfor %}
 {%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040282.sls
@@ -7,7 +7,7 @@
 # Finding Level: medium
 #
 # Rule Summary:
-#       RHEL 8 SRG-OS-000480-GPOS-00227
+#       The OS must restrict usage of ptrace to descendant processes.
 #
 # References:
 #   CCI:

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040282.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040282.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r9
 # Finding ID: V-230546
 # Rule ID:    SV-230546r858824_rule
@@ -7,7 +9,7 @@
 # Finding Level: medium
 #
 # Rule Summary:
-#       RHEL 8 SRG-OS-000480-GPOS-00227
+#       The OS must restrict usage of ptrace to descendant processes.
 #
 # References:
 #   CCI:
@@ -17,39 +19,16 @@
 #   NIST SP 800-53 Revision 4 :: CM-6 b
 #
 ###########################################################################
-{%- set stig_id = 'RHEL-08-040282' %}
-{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
-{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
-{%- set searchDirs =[
-  '/etc/sysctl.d/',
-  '/lib/sysctl.d/',
-  '/run/sysctl.d',
-  '/usr/lib/sysctl.d',
-  '/usr/local/lib/sysctl.d',
-] %}
-{%- set sysctlFiles = [ '/etc/sysctl.conf' ] %}
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
 
-script_{{ stig_id }}-describe:
-  cmd.script:
-    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
-    - cwd: /root
-    - stateful: True
-
-{%- if stig_id in skipIt %}
-notify_{{ stig_id }}-skipSet:
-  cmd.run:
-    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
-    - stateful: True
-    - cwd: /root
-{%- else %}
-  {%- for searchDir in searchDirs %}
-    {%- do sysctlFiles.extend(salt.file.find(searchDir, type='f', name='*.conf', grep='kernel\.yama\.ptrace_scope')) %}
-  {%- endfor %}
-  {%- for sysctlFile in sysctlFiles %}
-Fix kernel.yama\.ptrace_scope in {{ sysctlFile }}:
-  file.replace:
-    - name: '{{ sysctlFile }}'
-    - pattern: '^(\s*|#(\s*|))(kernel\.yama\.ptrace_scope)(\s*=\s*).*$'
-    - repl: '\3\4|/bin/false'
-  {%- endfor %}
-{%- endif %}
+diag_out "--------------------------------------"
+diag_out "STIG Finding ID: V-230311"
+diag_out "     The OS must restrict usage of the"
+diag_out "     ptrace utility to descendant"
+diag_out "     processes."
+diag_out "--------------------------------------"
+diag_out ""
+diag_out "changed=no"

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040282.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040282.sh
@@ -1,0 +1,55 @@
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230546
+# Rule ID:    SV-230546r858824_rule
+# STIG ID:    RHEL-08-040282
+# SRG ID:     SRG-OS-000480-GPOS-00227
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       RHEL 8 SRG-OS-000480-GPOS-00227
+#
+# References:
+#   CCI:
+#     - CCI-000366
+#   NIST SP 800-53 :: CM-6 b
+#   NIST SP 800-53A :: CM-6.1 (iv)
+#   NIST SP 800-53 Revision 4 :: CM-6 b
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-040282' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set searchDirs =[
+  '/etc/sysctl.d/',
+  '/lib/sysctl.d/',
+  '/run/sysctl.d',
+  '/usr/lib/sysctl.d',
+  '/usr/local/lib/sysctl.d',
+] %}
+{%- set sysctlFiles = [ '/etc/sysctl.conf' ] %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+    - stateful: True
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+  {%- for searchDir in searchDirs %}
+    {%- do sysctlFiles.extend(salt.file.find(searchDir, type='f', name='*.conf', grep='kernel\.yama\.ptrace_scope')) %}
+  {%- endfor %}
+  {%- for sysctlFile in sysctlFiles %}
+Fix kernel.yama\.ptrace_scope in {{ sysctlFile }}:
+  file.replace:
+    - name: '{{ sysctlFile }}'
+    - pattern: '^(\s*|#(\s*|))(kernel\.yama\.ptrace_scope)(\s*=\s*).*$'
+    - repl: '\3\4|/bin/false'
+  {%- endfor %}
+{%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/init.sls
+++ b/ash-linux/el8/STIGbyID/cat2/init.sls
@@ -22,3 +22,4 @@ include:
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020231
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-030740
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-040123
+  - ash-linux.el8.STIGbyID.cat2.RHEL-08-040282


### PR DESCRIPTION
Searches the `/etc/sysctl.d/`, `/lib/sysctl.d/`, `/run/sysctl.d`, `/usr/lib/sysctl.d' and `/usr/local/lib/sysctl.d` directories for files containing any setting the `kernel.yama.ptrace_scope` tunable and ensures the value is set to `1. Also checks the `/etc/sysctl.conf` and does the same 

Closes #370

