### PR TITLE
Add handlers for RHEL-08-010161

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-010161.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-010161.sls
@@ -1,0 +1,48 @@
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230238
+# Rule ID:    SV-230238r646862_rule
+# STIG ID:    RHEL-08-010161
+# SRG ID:     SRG-OS-000120-GPOS-00061
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must prevent system daemons from using
+#       Kerberos for authentication
+#
+# References:
+#   CCI:
+#     - CCI-000803
+#   NIST SP 800-53 :: IA-7
+#   NIST SP 800-53A :: IA-7.1
+#   NIST SP 800-53 Revision 4 :: IA-7
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-010161' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set keytabList = salt.file.find('/etc', maxdepth=1, type='f', name='*.keytab') %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+  {%- for keytab in keytabList %}
+Delete suspect {{ keytab }} file:
+  file.absent:
+    - name: '{{ keytab }}'
+    - unless:
+      - fun: pkg.version
+        args:
+          - krb5-workstation
+          - krb5-server
+  {%- endfor %}
+{%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-010161.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-010161.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Ref Doc:    STIG - RHEL 8 v1r9
+# Finding ID: V-230238
+# Rule ID:    SV-230238r646862_rule
+# STIG ID:    RHEL-08-010161
+# SRG ID:     SRG-OS-000120-GPOS-00061
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must prevent system daemons from using
+#       Kerberos for authentication
+#
+# References:
+#   CCI:
+#     - CCI-000803
+#   NIST SP 800-53 :: IA-7
+#   NIST SP 800-53A :: IA-7.1
+#   NIST SP 800-53 Revision 4 :: IA-7
+#
+###########################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "--------------------------------------"
+diag_out "STIG Finding ID: V-248543"
+diag_out "     The OS system must prevent system"
+diag_out "     daemons from using Kerberos for"
+diag_out "     authentication"
+diag_out "--------------------------------------"

--- a/ash-linux/el8/STIGbyID/cat2/init.sls
+++ b/ash-linux/el8/STIGbyID/cat2/init.sls
@@ -2,6 +2,7 @@ include:
   - ash-linux.el8.STIGbyID.cat2.OL08-00-010159
   - ash-linux.el8.STIGbyID.cat2.OL08-00-010160
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-010001
+  - ash-linux.el8.STIGbyID.cat2.RHEL-08-010161
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-010200
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-010490
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-010571


### PR DESCRIPTION
Looks for and deletes any `.keytab` files in `/etc` if neither the `krb5-workstation` nor the `krb5-serve` RPMs is installed.

Closes #359 