### PR TITLE
Uses el7 and el8 compatible method to redirect oscap output and preserve return code

### DIFF
--- a/ash-linux/el7/VendorSTIG/remediate.sls
+++ b/ash-linux/el7/VendorSTIG/remediate.sls
@@ -22,7 +22,7 @@
 
 run_{{ stig_id }}-remediate:
   cmd.run:
-    - name: 'oscap xccdf eval --remediate --profile {{ scapProf }} {{ dsfile }} 2>&1 | tee /var/log/oscap.log ; exit $PIPESTATUS[0]'
+    - name: 'oscap xccdf eval --remediate --profile {{ scapProf }} {{ dsfile }} > >(tee /var/log/oscap.log) 2>&1'
     - cwd: '/root'
     - success_retcodes:
       - 2

--- a/ash-linux/el8/VendorSTIG/remediate.sls
+++ b/ash-linux/el8/VendorSTIG/remediate.sls
@@ -24,7 +24,7 @@
 
 run_{{ stig_id }}-remediate:
   cmd.run:
-    - name: 'oscap xccdf eval --remediate --profile {{ scapProf }} {{ dsfile }} 2>&1 | tee /var/log/oscap.log ; exit $PIPESTATUS[0]'
+    - name: 'oscap xccdf eval --remediate --profile {{ scapProf }} {{ dsfile }} > >(tee /var/log/oscap.log) 2>&1'
     - cwd: '/root'
     - success_retcodes:
       - 2


### PR DESCRIPTION
Using PIPESTATUS on el7 resulted in the error:

    /bin/bash: line 0: exit: 2[0]: numeric argument required