### PR TITLE
Gets Rid of Redundant `notRpm` State

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020011.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020011.sls
@@ -38,11 +38,15 @@ notify_{{ stig_id }}-skipSet:
     - cwd: /root
 {%- else %}
 # Replace RPM-delivered content
-file_{{ stig_id }}-{{ targFile }}_fromRpm:
+file_{{ stig_id }}-{{ targFile }}:
   file.replace:
     - name: {{ targFile }}
-    - pattern: '(^# Deny access.*\n.*\n# The default is.*\n# deny.*$)'
-    - repl: '\1\n{{ cfgParm }} = {{ cfgVal }}'
-    - unless:
-      - 'rpm -qVf {{ targFile }} | grep -qE "([mM]|\.)5.*{{ targFile }}"'
+    - append_if_not_found: True
+    - not_found_content: '{{ cfgParm }} = {{ cfgVal }}'
+    - onlyif:
+      - fun: pkg.version
+        args:
+          - pam
+    - pattern: '^(\s*|#\s*)({{ cfgParm }})(\s*=\s*)(\d*)'
+    - repl: '\g<2>\g<3>{{ cfgVal }}'
 {%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020011.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020011.sls
@@ -45,13 +45,4 @@ file_{{ stig_id }}-{{ targFile }}_fromRpm:
     - repl: '\1\n{{ cfgParm }} = {{ cfgVal }}'
     - unless:
       - 'rpm -qVf {{ targFile }} | grep -qE "([mM]|\.)5.*{{ targFile }}"'
-
-# Replace non RPM-delivered content
-file_{{ stig_id }}-{{ targFile }}_notRpm:
-  file.replace:
-    - name: {{ targFile }}
-    - pattern: '^(|\s){{ cfgParm }}(\s*=\s*)\d*'
-    - repl: '{{ cfgParm }} = {{ cfgVal }}'
-    - onlyif:
-      - 'rpm -qVf {{ targFile }} | grep -qE "([mM]|\.)5.*{{ targFile }}"'
 {%- endif %}


### PR DESCRIPTION
Also:
- renames remaining modification-state, removing the `_fromRpm` suffix
- changes requisite method
- updates replacement-regex
- ensures appropriate content is added if there's no match to the regex

Closes #395