### PR TITLE
Configure OS to prevent overwriting custom authentication configuration settings by the authconfigutility.

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-010199.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-010199.sls
@@ -1,0 +1,86 @@
+#################################################################
+{%- set stig_id = 'RHEL-07-010199' %}
+{%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set targFileList = [
+    '/etc/pam.d/system-auth',
+    '/etc/pam.d/password-auth',
+] %}
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+##############################################
+## Set up "clean" files from downloaded-RPM ##
+Clean out cached pam RPM(s):
+  module.run:
+    - name: file.find
+    - path: '/var/cache/yum/packages'
+    - kwargs:
+        type: 'f'
+        name: 'pam-*.rpm'
+        delete: 'f'
+
+Re-download pam RPM: # Just in case we need it...
+  module.run:
+    - name: 'pkg.download'
+    - packages:
+      - 'pam'
+
+Unpack downloaded RPM:
+  cmd.run:
+    - name: |
+        mkdir /tmp/.{{ stig_id }}.d
+        rpm2cpio /var/cache/yum/packages/pam-*.rpm \
+        | ( cd /tmp/.RHEL-07-010199.d/ && cpio -idv ./etc/pam.d/*-auth)
+
+##                                          ##
+##############################################
+
+  {%- for targFile in targFileList %}
+# Make sure existing file isn't a symlink to the authconfig-managed source
+Delete {{ targFile }} authconfig symlink:
+  file.absent:
+    - name: '{{ targFile }}'
+    - onlyif:
+      - '[[ -e {{ targFile }}-ac ]]'
+      - '[[ $( readlink -f {{ targFile }} ) ==  {{ targFile }}-ac ]]'
+
+# Restore from RPM if we nuked the symlink to the authconfig-managed source
+Restore {{ targFile }} from RPM-contents:
+  file.copy:
+    - name: '{{ targFile }}'
+    - onchanges:
+      - file: 'Delete {{ targFile }} authconfig symlink'
+    - source: '/tmp/.{{ stig_id }}.d{{ targFile }}'
+
+# If not a symlink to <FILE>-local, move it to <FILE>-local
+Move {{ targFile }} to {{ targFile }}-local:
+  file.rename:
+    - name: '{{ targFile }}-local'
+    - require:
+      - file: 'Restore {{ targFile }} from RPM-contents'
+    - source: '{{ targFile }}'
+    - unless:
+      - '[[ -L {{ targFile }} ]]'
+      - '[[ -e {{ targFile }}-local ]]'
+
+# Symlink <FILE> to <FILE>-local
+Symlink {{ targFile }} to {{ targFile }}-local:
+  file.symlink:
+    - name: '{{ targFile }}'
+    - target: '{{ targFile }}-local'
+    - onchanges:
+      - file: 'Move {{ targFile }} to {{ targFile }}-local'
+    - require_in:
+      - file: 'Clean up unpacked RPM'
+  {%- endfor %}
+
+Clean up unpacked RPM:
+  file.absent:
+    - name: '/tmp/.RHEL-07-010199.d'
+{%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-010199.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-010199.sls
@@ -1,3 +1,23 @@
+# Ref Doc:    STIG - RHEL 7 v3r11
+# Finding ID: V-255928
+# Rule ID:    SV-255928r902706_rule
+# STIG ID:    RHEL-07-010199
+# SRG ID:     SRG-OS-000073-GPOS-00041
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must be configured to prevent overwriting of
+#       custom authentication configuration settings by the authconfig
+#       utility.
+#
+# References:
+#   CCI:
+#     - CCI-000196
+#       - NIST SP 800-53 :: IA-5 (1) (c)
+#       - NIST SP 800-53A :: IA-5 (1).1 (v)
+#       - NIST SP 800-53 Revision 4 :: IA-5 (1) (c)
+#
 #################################################################
 {%- set stig_id = 'RHEL-07-010199' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}

--- a/ash-linux/el7/STIGbyID/cat2/files/RHEL-07-010199.sh
+++ b/ash-linux/el7/STIGbyID/cat2/files/RHEL-07-010199.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Ref Doc:    STIG - RHEL 7 v3r11
+# Finding ID: V-255928
+# Rule ID:    SV-255928r902706_rule
+# STIG ID:    RHEL-07-010199
+# SRG ID:     SRG-OS-000073-GPOS-00041
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must be configured to prevent overwriting of
+#       custom authentication configuration settings by the authconfig
+#       utility.
+#
+# References:
+#   CCI:
+#     - CCI-000196
+#       - NIST SP 800-53 :: IA-5 (1) (c)
+#       - NIST SP 800-53A :: IA-5 (1).1 (v)
+#       - NIST SP 800-53 Revision 4 :: IA-5 (1) (c)
+#
+#################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "----------------------------------------"
+diag_out "STIG Finding ID: RHEL-07-010199"
+diag_out "   The OS must be configured to prevent"
+diag_out "   overwriting of PAM files by the"
+diag_out "   authconfig utility"
+diag_out "----------------------------------------"

--- a/ash-linux/el7/STIGbyID/cat2/init.sls
+++ b/ash-linux/el7/STIGbyID/cat2/init.sls
@@ -15,6 +15,7 @@ include:
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010170
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010180
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010190
+  - ash-linux.el7.STIGbyID.cat2.RHEL-07-010199
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010200
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010210
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-010220


### PR DESCRIPTION
- If `{password,system}` auth exists and links to `-ac` file, nuke it and recreate from RPM sources
- If `{password,system}` auth exists and links to nothing, move it to `{password,system}-local` and recreate `{password,system}` as links to `{password,system}-local`

Closes #400

