### PR TITLE
Split file- and dir-find actions

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020320.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020320.sls
@@ -1,7 +1,9 @@
-# Finding ID:	RHEL-07-020360
-# Version:	RHEL-07-020360_rule
-# SRG ID:	SRG-OS-000480-GPOS-00227
-# Finding Level:	medium
+# Ref Doc:        STIG - RHEL 7 v3r11
+# Finding ID:     V-204463
+# STIG ID:	      RHEL-07-020320
+# Version:        RHEL-07-020320_rule
+# SRG ID:         SRG-OS-000480-GPOS-00227
+# Finding Level:  medium
 #
 # Rule Summary:
 #	All files and directories must have a valid owner.
@@ -10,7 +12,7 @@
 #    NIST SP 800-53 Revision 4 :: AC-3 (4)
 #
 #################################################################
-{%- set stig_id = 'RHEL-07-020360' %}
+{%- set stig_id = 'RHEL-07-020320' %}
 {%- set helperLoc = 'ash-linux/el7/STIGbyID/cat2/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set nouserFiles = [] %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020360.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020360.sls
@@ -41,7 +41,7 @@ notify_{{ stig_id }}-skipSet:
   {%- for mount in mounts %}
     {%- set mountType = mountData[mount]['fstype'] %}
     {%- if mountData[mount]['fstype'] in localFstypes %}
-      {%- set foundString = salt['cmd.shell']('find ' + mount + ' -xdev -nouser') %}
+      {%- set foundString = salt['cmd.shell']('find ' + mount + ' -type d -xdev -nouser') %}
       {%- set foundList = foundString.split('\n') %}
       {%- do nouserFiles.extend(foundList) %}
     {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/files/RHEL-07-020320.sh
+++ b/ash-linux/el7/STIGbyID/cat2/files/RHEL-07-020320.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-# Finding ID:	RHEL-07-020360
-# Version:	RHEL-07-020360_rule
-# SRG ID:	SRG-OS-000480-GPOS-00227
-# Finding Level:	medium
+# Ref Doc:        STIG - RHEL 7 v3r11
+# Finding ID:     V-204463
+# STIG ID:        RHEL-07-020320
+# Version:        RHEL-07-020320_rule
+# SRG ID:         SRG-OS-000480-GPOS-00227
+# Finding Level:  medium
 # 
 # Rule Summary:
 #	All files and directories must have a valid owner.
@@ -17,7 +19,7 @@ diag_out() {
 }
 
 diag_out "----------------------------------------"
-diag_out "STIG Finding ID: RHEL-07-020360"
+diag_out "STIG Finding ID: RHEL-07-020320"
 diag_out "   All files and directories must have"
 diag_out "   a valid owner."
 diag_out "----------------------------------------"

--- a/ash-linux/el7/STIGbyID/cat2/init.sls
+++ b/ash-linux/el7/STIGbyID/cat2/init.sls
@@ -41,7 +41,7 @@ include:
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020230
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020260
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020290
-  - ash-linux.el7.STIGbyID.cat2.RHEL-07-020360
+  - ash-linux.el7.STIGbyID.cat2.RHEL-07-020320
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020370
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020620
   - ash-linux.el7.STIGbyID.cat2.RHEL-07-020630


### PR DESCRIPTION
The saltstack states for setting file and directory ownership are different, therefore, the object-finding list-creation logic needed to be tightened up. The STIG-handler now does one find for files with missing/unmapped user-ownership and one find for directories with missing/unmapped user-ownership.

Added "nothing found"  outputter to make things more-obvious that _something_ was executed to anyone reviewing logs

Could not convert to using `salt.file.find` since the native salt-module still doesn't (appear to) support the ability to look for `-nouser` attributes. 

Closes #407 