### PR TITLE
WIP: Ensure all existing scripts pass a basic lint

### DIFF
--- a/ash-linux/el8/STIGbyID/cat1/files/RHEL-08-010150.sh
+++ b/ash-linux/el8/STIGbyID/cat1/files/RHEL-08-010150.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r7
 # Finding ID: V-230235
 # STIG ID:    RHEL-08-010150

--- a/ash-linux/el8/STIGbyID/cat1/files/RHEL-08-020331.sh
+++ b/ash-linux/el8/STIGbyID/cat1/files/RHEL-08-020331.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r7
 # Finding ID: V-244540
 # Rule ID:    SV-244540r743869_rule

--- a/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-020042.sh
+++ b/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-020042.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r7
 # Finding ID: V-230350
 # Rule ID:    SV-230350r627750_rule

--- a/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-020340.sh
+++ b/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-020340.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r7
 # Finding ID: V-230381
 # Rule ID:    SV-230381r627750_rule

--- a/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-030603.sh
+++ b/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-030603.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r7
 # Finding ID: V-230470
 # Rule ID:    SV-230470r744006_rule

--- a/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-030742.sh
+++ b/ash-linux/el8/STIGbyID/cat3/files/RHEL-08-030742.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Ref Doc:    STIG - RHEL 8 v1r9
 # Finding ID: V-230486
 # Rule ID:    SV-230486r627750_rule


### PR DESCRIPTION
In order to implement #409, it will be necessary to ensure that all, currently-existing scripts in this project pass a basic lint. Doing so will also allow the closure of #410.