### PR TITLE
Add remediation for RHEL-08-040090

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
@@ -60,7 +60,7 @@ Set Default firewalld zone - config-running:
 Set Minimum Ports:
   firewalld.present:
     - name: '{{ firewalldValu }}'
-    - requires:
+    - require:
       - module: 'Set Default firewalld zone - config-running'
     - ports: {{ firewalldSafePorts }}
     - prune_ports: False

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
@@ -60,7 +60,7 @@ Set Default firewalld zone - config-running:
 Set Minimum Ports:
   firewalld.present:
     - name: '{{ firewalldValu }}'
-    - onchanges:
+    - requires:
       - module: 'Set Default firewalld zone - config-running'
     - ports: {{ firewalldSafePorts }}
     - prune_ports: False

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-040090.sls
@@ -1,0 +1,69 @@
+# Ref Doc:    STIG - RHEL 8 v1r10
+# Finding ID: V-230238
+# Rule ID:    SV-230504r854047_rule
+# STIG ID:    RHEL-08-040090
+# SRG ID:     SRG-OS-000297-GPOS-00115
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must enable a firewall service that  employs
+#       a deny-all, allow-by-exception policy for allowing connections to
+#       other systems.
+#
+# References:
+#   CCI:
+#     - CCI-002314
+#   NIST SP 800-53 Revision 4 :: AC-17 (1)
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-040090' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set firewalldConf = '/etc/firewalld/firewalld.conf' %}
+{%- set firewalldParm = 'DefaultZone' %}
+{%- set firewalldValu = salt.pillar.get('ash-linux:lookup:def_firewall_zone', 'drop') %}
+{%- set firewalldSafePorts = salt.pillar.get('ash-linux:lookup:def_firewall_ports', [] ) %}
+{%- set firewalldSafeSvcs = salt.pillar.get('ash-linux:lookup:def_firewall_services', [ 'ssh', ] ) %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+Set Default firewalld zone - config-file:
+  file.replace:
+    - name: '{{ firewalldConf }}'
+    - pattern: '^({{ firewalldParm }})(\s*=\s*).*'
+    - repl: '\1=drop'
+    - append_if_not_found: True
+    - not_found_content: |-
+        # Inserted per STIG {{ stig_id }}
+        {{ firewalldParm }}={{ firewalldValu }}
+
+Set Default firewalld zone - config-running:
+  module.run:
+    - name: firewalld.set_default_zone
+    - onchanges:
+      - file: 'Set Default firewalld zone - config-file'
+    - unless:
+      - '[[ $( firewall-cmd --get-default-zone ) == "drop" ]]'
+    - zone: drop
+
+Set Minimum Ports:
+  firewalld.present:
+    - name: '{{ firewalldValu }}'
+    - onchanges:
+      - module: 'Set Default firewalld zone - config-running'
+    - ports: {{ firewalldSafePorts }}
+    - prune_ports: False
+    - prune_services: False
+    - services: {{ firewalldSafeSvcs }}
+{%- endif %}

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040090.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-040090.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Ref Doc:    STIG - RHEL 8 v1r10
+# Finding ID: V-230238
+# Rule ID:    SV-230504r854047_rule
+# STIG ID:    RHEL-08-040090
+# SRG ID:     SRG-OS-000297-GPOS-00115
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The operating system must enable a firewall service that  employs
+#       a deny-all, allow-by-exception policy for allowing connections to
+#       other systems.
+#
+# References:
+#   CCI:
+#     - CCI-002314
+#   NIST SP 800-53 Revision 4 :: AC-17 (1)
+#
+###########################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "--------------------------------------"
+diag_out "STIG Finding ID: V-230238"
+diag_out "     The OS activate a host-based"
+diag_out "     firewall service with a default"
+diag_out "     'deny-all' posture"
+diag_out "--------------------------------------"

--- a/ash-linux/el8/STIGbyID/cat2/init.sls
+++ b/ash-linux/el8/STIGbyID/cat2/init.sls
@@ -22,6 +22,7 @@ include:
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020221
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020231
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-030740
+  - ash-linux.el8.STIGbyID.cat2.RHEL-08-040090
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-040123
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-040282
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-040290

--- a/tests/requirements-el7.txt
+++ b/tests/requirements-el7.txt
@@ -1,4 +1,3 @@
 grub2
-firewalld
 postfix
 sudo

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ audit
 openssh-server
 rsyslog
 salt-minion
+firewalld


### PR DESCRIPTION
It _appears_ that the OSCAP content already takes care of this, but this will still show up on _some_ hardening-scans. Adding this state to make it easier to point auditors to a block of code that easily tells them, "yes, watchmaker _is_ setting this, appropriately"

Closes #422