### PR TITLE
Add handler for V-244533 (RHEL-08-020025)

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
@@ -26,7 +26,6 @@
 {%- if salt.file.is_link(targFile) %}
   {%- set targFile = salt.cmd.run('readlink -f ' + targFile) %}
 {%- endif %}
-{%- set searchRoot = '^password\s+required\s+pam_pwhistory.so\s+' %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
@@ -55,7 +55,7 @@ Ensure auth pam_faillock.so preauth before pam_faillock.so authfail:
     - require:
       - file: 'Ensure auth pam_faillock.so authfail before pam_unix.so'
     - unless:
-      - '[[ $( grep -Pq "^auth\s*required\s*pam_faillock.so\s*preauth" {{ targFile }} )$? -eq 0 ]]'
+      - grep -Pq "^auth\s*required\s*pam_faillock.so\s*preauth" {{ targFile }}
 
 Ensure accunt pam_faillock.so before pam_unix.so:
   file.replace:

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
@@ -45,7 +45,7 @@ Ensure auth pam_faillock.so authfail before pam_unix.so:
     - pattern: '(^auth\s*(sufficient|\[.*])\s*pam_unix.so.*)'
     - repl: 'auth        required                                     pam_faillock.so authfail\n\1'
     - unless:
-      - '[[ $( grep -Pq "^auth\s*required\s*pam_faillock.so\s*authfail" {{ targFile }} )$? -eq 0 ]]'
+      - grep -Pq "^auth\s*required\s*pam_faillock.so\s*authfail" {{ targFile }}
 
 Ensure auth pam_faillock.so preauth before pam_faillock.so authfail:
   file.replace:

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
@@ -63,6 +63,6 @@ Ensure accunt pam_faillock.so before pam_unix.so:
     - pattern: '(^account\s*required\s*pam_unix.so.*)'
     - repl: 'account     required                                     pam_faillock.so\n\1'
     - unless:
-      - '[[ $( grep -Pq "^account\s*required\s*pam_faillock.so" /etc/authselect/system-auth )$? -eq 0 ]]'
+      - grep -Pq "^account\s*required\s*pam_faillock.so" {{ targFile }}
 {%- endif %}
 

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020025.sls
@@ -1,0 +1,69 @@
+# Ref Doc:    STIG - RHEL 8 v1r10
+# Finding ID: V-244533
+# Rule ID:    SV-244533r743848_rule
+# STIG ID:    RHEL-08-020025
+# SRG ID:     SRG-OS-000021-GPOS-00005
+#             SRG-OS-000329-GPOS-00128
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The OS must configure the use of the pam_faillock.so module in the
+#       /etc/pam.d/system-auth file.
+#
+# References:
+#   CCI:
+#     - CCI-000044
+#       - NIST SP 800-53 :: AC-7 a
+#       - NIST SP 800-53A :: AC-7.1 (ii)
+#       - NIST SP 800-53 Revision 4 :: AC-7 a
+#
+###########################################################################
+{%- set stig_id = 'RHEL-08-020025' %}
+{%- set helperLoc = 'ash-linux/el8/STIGbyID/cat2/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set targFile = '/etc/pam.d/system-auth' %}
+{%- if salt.file.is_link(targFile) %}
+  {%- set targFile = salt.cmd.run('readlink -f ' + targFile) %}
+{%- endif %}
+{%- set searchRoot = '^password\s+required\s+pam_pwhistory.so\s+' %}
+
+script_{{ stig_id }}-describe:
+  cmd.script:
+    - source: salt://{{ helperLoc }}/{{ stig_id }}.sh
+    - cwd: /root
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  cmd.run:
+    - name: 'printf "\nchanged=no comment=''Handler for {{ stig_id }} has been selected for skip.''\n"'
+    - stateful: True
+    - cwd: /root
+{%- else %}
+Ensure auth pam_faillock.so authfail before pam_unix.so:
+  file.replace:
+    - name: '{{ targFile }}'
+    - pattern: '(^auth\s*(sufficient|\[.*])\s*pam_unix.so.*)'
+    - repl: 'auth        required                                     pam_faillock.so authfail\n\1'
+    - unless:
+      - '[[ $( grep -Pq "^auth\s*required\s*pam_faillock.so\s*authfail" {{ targFile }} )$? -eq 0 ]]'
+
+Ensure auth pam_faillock.so preauth before pam_faillock.so authfail:
+  file.replace:
+    - name: '{{ targFile }}'
+    - pattern: '(^auth\s*required\s*pam_faillock.so authfail)'
+    - repl: 'auth        required                                     pam_faillock.so preauth\n\1'
+    - require:
+      - file: 'Ensure auth pam_faillock.so authfail before pam_unix.so'
+    - unless:
+      - '[[ $( grep -Pq "^auth\s*required\s*pam_faillock.so\s*preauth" {{ targFile }} )$? -eq 0 ]]'
+
+Ensure accunt pam_faillock.so before pam_unix.so:
+  file.replace:
+    - name: '{{ targFile }}'
+    - pattern: '(^account\s*required\s*pam_unix.so.*)'
+    - repl: 'account     required                                     pam_faillock.so\n\1'
+    - unless:
+      - '[[ $( grep -Pq "^account\s*required\s*pam_faillock.so" /etc/authselect/system-auth )$? -eq 0 ]]'
+{%- endif %}
+

--- a/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020025.sh
+++ b/ash-linux/el8/STIGbyID/cat2/files/RHEL-08-020025.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Ref Doc:    STIG - RHEL 8 v1r10
+# Finding ID: V-244533
+# Rule ID:    SV-244533r743848_rule
+# STIG ID:    RHEL-08-020025
+# SRG ID:     SRG-OS-000021-GPOS-00005
+#             SRG-OS-000329-GPOS-00128
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The OS must configure the use of the pam_faillock.so module in the
+#       /etc/pam.d/system-auth file.
+#
+# References:
+#   CCI:
+#     - CCI-000044
+#       - NIST SP 800-53 :: AC-7 a
+#       - NIST SP 800-53A :: AC-7.1 (ii)
+#       - NIST SP 800-53 Revision 4 :: AC-7 a
+#
+###########################################################################
+# Standard outputter function
+diag_out() {
+   echo "${1}"
+}
+
+diag_out "--------------------------------------"
+diag_out "STIG Finding ID: V-244533"
+diag_out "     OS must configure pam_faillock"
+diag_out "     module before pam_unix in the"
+diag_out "     /etc/pam.d/system-auth file"
+diag_out "--------------------------------------"

--- a/ash-linux/el8/STIGbyID/cat2/init.sls
+++ b/ash-linux/el8/STIGbyID/cat2/init.sls
@@ -14,6 +14,7 @@ include:
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020015
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020019
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020021
+  - ash-linux.el8.STIGbyID.cat2.RHEL-08-020025
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020040
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020041
   - ash-linux.el8.STIGbyID.cat2.RHEL-08-020090


### PR DESCRIPTION
Ensures STIG-required `pam_faillock.so`  exist and exist in the proper stack-order(s)

Closes #423