### PR TITLE
Allow fine-tuning of SELinux user-mappings

### DIFF
--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
@@ -79,4 +79,21 @@ Map {{ userName }} to user_u:
       - 'semanage login -ln | grep "{{ userName }} "'
     {%- endif %}
   {%- endfor %}
+
+Set "__default__" SELinux user-mapping to "user_u":
+  test.show_notification:
+    - text: |
+        This state is currently a NOOP.
+
+        Per {{ stig_id }}, the `__default__` user-mapping *should* be set to
+        `user_u`. However, doing this would cause users that authenticate to the
+        host via many third-party authentication-services to not be able to
+        execute the `sudo` command.  Because the many of the users of this
+        formula are using third-party authentication-services, this handler will
+        not implement the STIG recommended setting.
+
+        For users lgging in via third-party authentication-service, it will be
+        necessary for those users to specify the `-r unconfined_r` and
+        `-t unconfined_t` when invoking `sudo`.
+
 {%- endif %}

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
@@ -21,10 +21,10 @@
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set stig_role = 'user_u' %}
 {%- set regUserGid = 1000 %}
-{%- set admUsers = [] %}
-{%- set stfUsers = [] %}
-{%- set uncUsers = [] %}
-{%- set nulUsers = [] %}
+{%- set admUsers = salt.pillar.get('ash-linux:lookup:sel_confine:adm-users', []) %}
+{%- set stfUsers = salt.pillar.get('ash-linux:lookup:sel_confine:staff-users', []) %}
+{%- set uncUsers = salt.pillar.get('ash-linux:lookup:sel_confine:unconfined-users', []) %}
+{%- set nulUsers = salt.pillar.get('ash-linux:lookup:sel_confine:null-users', []) %}
 
 script_{{ stig_id }}-describe:
   cmd.script:

--- a/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
+++ b/ash-linux/el7/STIGbyID/cat2/RHEL-07-020020.sls
@@ -22,6 +22,9 @@
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set stig_role = 'user_u' %}
 {%- set regUserGid = 1000 %}
+{%- set guestUsers = salt.pillar.get('ash-linux:lookup:sel_confine:guest_u', []) %}
+{%- set nullUsers = salt.pillar.get('ash-linux:lookup:sel_confine:null_u', []) %}
+{%- set rootUsers = salt.pillar.get('ash-linux:lookup:sel_confine:root_u', []) %}
 {%- set staffUsers      = salt.pillar.get('ash-linux:lookup:sel_confine:staff_u', []) %}
 {%- set sysadmUsers     = salt.pillar.get('ash-linux:lookup:sel_confine:sysadm_u', []) %}
 {%- set unconfinedUsers = salt.pillar.get('ash-linux:lookup:sel_confine:unconfined_u', []) %}
@@ -41,6 +44,33 @@ notify_{{ stig_id }}-skipSet:
   {%- for userName in salt.user.list_users() %}
     {%- set userInfo = salt.user.info(userName) %}
     {%- if userInfo.gid >= regUserGid %}
+
+# Assign Pillar-specified users to 'guest_u' SEL-role
+      {%- if userName in guestUsers %}
+Map {{ userName }} to guest_u:
+  cmd.run:
+    - name: 'semanage login {{ userName }} -a -s guest_u'
+    - unless:
+      - 'semanage login -ln | grep "{{ userName }} "'
+      {%- endif %}
+
+# Assign Pillar-specified users to 'null_u' SEL-role
+      {%- if userName in nullUsers %}
+Map {{ userName }} to null_u:
+  cmd.run:
+    - name: 'semanage login {{ userName }} -a -s null_u'
+    - unless:
+      - 'semanage login -ln | grep "{{ userName }} "'
+      {%- endif %}
+
+# Assign Pillar-specified users to 'root_u' SEL-role
+      {%- if userName in rootUsers %}
+Map {{ userName }} to root_u:
+  cmd.run:
+    - name: 'semanage login {{ userName }} -a -s root_u'
+    - unless:
+      - 'semanage login -ln | grep "{{ userName }} "'
+      {%- endif %}
 
 # Assign Pillar-specified users to 'staff_u' SEL-role
       {%- if userName in staffUsers %}

--- a/pillar.example
+++ b/pillar.example
@@ -52,13 +52,13 @@
 
        # Users that should get specific confinements other that 'user_u'
 ##     sel_confine:
-##       guest-users:      # Users that should be mapped to the 'guest_u' confinement
-##       root-users:       # Users that should be mapped to the 'root' confinement
-##       staff-users:      # Users that should be mapped to the 'staff_u' confinement
-##       adm-users:        # Users that should be mapped to the 'sysadm_u' confinement
-##       system-users:     # Users that should be mapped to the 'system_u' confinement
-##       unconfined-users: # Users that should be mapped to the 'unconfined_u' confinement
-##       null-users:       # Users that should be not be mapped to a confinement
+##       guest_u:      # Users that should be mapped to the 'guest_u' confinement
+##       root_u:       # Users that should be mapped to the 'root' confinement
+##       staff_u:      # Users that should be mapped to the 'staff_u' confinement
+##       sysadm_u:     # Users that should be mapped to the 'sysadm_u' confinement
+##       system_u:     # Users that should be mapped to the 'system_u' confinement
+##       unconfined_u: # Users that should be mapped to the 'unconfined_u' confinement
+##       null_u:       # Users that should be not be mapped to a confinement
 
 
        # List of accounts that should be banned from deployed systems

--- a/pillar.example
+++ b/pillar.example
@@ -48,6 +48,18 @@
        # Action to take if audispd is unable to send logs to a
        # remote collector-host
 ##     audisp-net-fail: <syslog|single|halt>
+#
+
+       # Users that should get specific confinements other that 'user_u'
+##     sel_confine:
+##       guest-users:      # Users that should be mapped to the 'guest_u' confinement
+##       root-users:       # Users that should be mapped to the 'root' confinement
+##       staff-users:      # Users that should be mapped to the 'staff_u' confinement
+##       adm-users:        # Users that should be mapped to the 'sysadm_u' confinement
+##       system-users:     # Users that should be mapped to the 'system_u' confinement
+##       unconfined-users: # Users that should be mapped to the 'unconfined_u' confinement
+##       null-users:       # Users that should be not be mapped to a confinement
+
 
        # List of accounts that should be banned from deployed systems
 ##     banned-accts


### PR DESCRIPTION
Adds the ability to read SELinux user-mapping associations from Pillar.

Closes #440 