### PR TITLE
Get rid of `exec` token

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020041.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020041.sls
@@ -46,7 +46,7 @@ file_{{ stig_id }}-{{ profileFile }}:
         # Check if tmux is available
         if [[ $( rpm -q tmux --quiet )$? -ne 0 ]] || [[ ! -x /usr/bin/tmux ]]
         then
-           exit
+           return
         fi
 
         # Check if shell is interactive

--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-020041.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-020041.sls
@@ -1,4 +1,4 @@
-# Ref Doc:    STIG - RHEL 8 v1r7
+# Ref Doc:    STIG - RHEL 8 v1r9
 # Finding ID: V-230349
 # STIG ID:    RHEL-08-020041
 # Rule ID:    SV-230349r833388_rule
@@ -43,16 +43,15 @@ file_{{ stig_id }}-{{ profileFile }}:
     - makedirs: True
     - dir_mode: '0755'
     - contents: |-
-        # Check if shell is interactive
-        if [[ $- == *i* ]] && [[ $( rpm --quiet -q tmux )$? -eq 0 ]]
+        # Check if tmux is available
+        if [[ $( rpm -q tmux --quiet )$? -ne 0 ]] || [[ ! -x /usr/bin/tmux ]]
         then
-           parent=$( ps -o ppid= -p $$ )
-           name=$( ps -o comm= -p $parent )
+           exit
+        fi
 
-           # Check if controlling-process is target-value
-           case "$name" in
-              sshd|login)
-                 exec tmux
-                 ;;
-           esac
+        # Check if shell is interactive
+        if [ "$PS1" ]; then
+          parent=$(ps -o ppid= -p $$)
+          name=$(ps -o comm= -p $parent)
+          case "$name" in (sshd|login) tmux ;; esac
         fi


### PR DESCRIPTION
While we're here:

* Split out "is `tmux` available else quit" logic so scanners won't incorrectly mark the greater-logic as invalid
* Change to using (STIG-prescribed) `PS1` instead of checking if shell-attribute indicates interactive ...scanners won't incorrectly mark the logic as invalid
* Use the more-compressed (STIG-prescribed) `case` statement ...so scanners won't incorrectly mark them as invalid
* Remove other "human-friendly" formatting decisions ...so scanners won't incorrectly mark them as invalid

Closes #459 