### PR TITLE
Replace deprecated Options-token with DirectoryMode configuration-directive

### DIFF
--- a/ash-linux/el8/STIGbyID/cat2/RHEL-08-010571.sls
+++ b/ash-linux/el8/STIGbyID/cat2/RHEL-08-010571.sls
@@ -43,4 +43,5 @@ file_{{ stig_id }}-{{ targMnt }}:
     - dir_mode: '0755'
     - contents: |-
         [Mount]
-        Options=mode=1777,strictatime,{{ mntOpt|join(",") }}
+        Options=strictatime,{{ mntOpt|join(",") }}
+        DirectoryMode=0700


### PR DESCRIPTION
Fixes problem where execution of the RHEL-08-010571 state renders `/boot` not mountable at boot-time by systemd.