### PR TITLE
Add a 'SCAP undo' state

### DIFF
--- a/ash-linux/el8/VendorSTIG/init.sls
+++ b/ash-linux/el8/VendorSTIG/init.sls
@@ -8,4 +8,5 @@
 include:
   - ash-linux.el8.VendorSTIG.packages
   - ash-linux.el8.VendorSTIG.remediate
+  - ash-linux.el8.VendorSTIG.scap_undos
   - ash-linux.el8.VendorSTIG.aws_cli_v2

--- a/ash-linux/el8/VendorSTIG/scap_undos.sls
+++ b/ash-linux/el8/VendorSTIG/scap_undos.sls
@@ -11,4 +11,4 @@ undo logcollector in /etc/rsyslog.conf:
     - name: '/etc/rsyslog.conf'
     - not_found_content: ''
     - pattern: '^(\s*|#*\s*|)\*\.\*\s*@*logcollector$'
-    - repl: '# *.* @logcollector'
+    - repl: ''

--- a/ash-linux/el8/VendorSTIG/scap_undos.sls
+++ b/ash-linux/el8/VendorSTIG/scap_undos.sls
@@ -7,6 +7,8 @@
 # Undo SCAP's appending of a `*.* @@logcollector` config-token in the
 # rsyslog.conf file
 undo logcollector in /etc/rsyslog.conf:
-  file.comment:
+  file.replace:
     - name: '/etc/rsyslog.conf'
-    - regex: '^(\s*|)\*\.\*\s*@@logcollector'
+    - not_found_content: ''
+    - pattern: '^(\s*|#*\s*|)\*\.\*\s*@*logcollector$'
+    - repl: '# *.* @logcollector'

--- a/ash-linux/el8/VendorSTIG/scap_undos.sls
+++ b/ash-linux/el8/VendorSTIG/scap_undos.sls
@@ -1,0 +1,12 @@
+# This Salt state undoes anything put in place by the
+# "remediate" state that shouldn't have been done as part of the
+# generic OSCAP content
+#
+#################################################################
+
+# Undo SCAP's appending of a `*.* @@logcollector` config-token in the
+# rsyslog.conf file
+undo logcollector in /etc/rsyslog.conf:
+  file.comment:
+    - name: '/etc/rsyslog.conf'
+    - regex: '^(\s*|)\*\.\*\s*@@logcollector'


### PR DESCRIPTION
Hopefully, the rsyslog "fix" logic is the only one we'll need (and, further hopefully, the content-maintainers accept and agree to fix the bug-repor about rsyslog and logcollector) to put here, but we now have a central place for adding such undos as necessary.

Closes #498

Note: if someone intentionally adds a `*.* @@logcollector` line to their host's `/etc/rsyslog.conf` file _before_ this state is run, this update will cause that entry to be commented out. That said, Red Hat generally recommends that remote-logging be set up in suitable `/etc/rsyslog.d/*` files (which this update wouldn't touch).