### PR TITLE
Generalize Existing alias-setting Logic

### DIFF
--- a/ash-linux/el9/RuleById/medium/content_rule_postfix_client_configure_mail_alias.sls
+++ b/ash-linux/el9/RuleById/medium/content_rule_postfix_client_configure_mail_alias.sls
@@ -35,6 +35,7 @@
         -------------------------------------------
         Make sure that mails delivered to root user
         are forwarded to a monitored email address.
+        (per: {{ stig_id }})
         -------------------------------------------
 
 {%- if stig_id in skipIt %}
@@ -46,8 +47,16 @@ notify_{{ stig_id }}-skipSet:
         -----------------------------------------------------
 {%- else %}
   {%- if emailUserMap %}
-    {%- for mailAliasFile in mailAliasFiles %}
-      {%- for key,value in emailUserMap.items() %}
+    {%- for key,value in emailUserMap.items() %}
+Action Description ({{ key }}):
+  test.show_notification:
+    - text: |
+        -------------------------------------------
+        Forward emails delivered to {{ key }} user
+        to {{ value }}
+        -------------------------------------------
+
+      {%- for mailAliasFile in mailAliasFiles %}
 Set email destinations ({{ key }} in {{ mailAliasFile }}):
   file.replace:
     - name: {{ mailAliasFile }}

--- a/pillar.example
+++ b/pillar.example
@@ -146,3 +146,12 @@
 ##           - aes128-gcm@openssh.com      #
 ##           - aes128-ctr                  #
 ##       client:                           # Client-related settings
+
+##     SMTP email alias configuration
+##     mail_aliases:
+##       root: <OFFHOST_EMAIL_ADDRESS>     # This must be defined to a valid
+##                                         # site-address to meet hardening
+##                                         # requirements
+##       user1: <DESTINATION_1>            # Extra aliases that site wants
+##       .....: ........                   # standardized onto...
+##       userN: <DESTINATION_N>            # ...


### PR DESCRIPTION
Updated to allow Watchmaker to configure not just the `root` user's email-destination (alias), but _any_ local account's email-destination. Change made to create a common Pillar-entry for all (local) users' aliases.

Closes #531 