### PR TITLE
Addresses need for handler to address `content_rule_require_singleuser_auth` rule

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
@@ -19,7 +19,10 @@
 {%- set helperLoc = tpldir ~ '/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set cfgFile = '/usr/lib/systemd/system/rescue.service' %}
-{%- set fixString = '/bin/sh -c "/sbin/sulogin ; /usr/bin/systemctl --fail --no-block default"' %}
+{%- set fixString = salt.pillar.get('ash-linux:lookup:rescue_shell_protection',
+          '/usr/lib/systemd/systemd-sulogin-shell rescue'
+        )
+%}
 
 {{ stig_id }}-description:
   test.show_notification:

--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
@@ -41,4 +41,19 @@ Require Authentication for Single User Mode:
     - name:  '{{ cfgFile }}'
     - pattern: '(^ExecStart=)(.*$)'
     - repl: '\g<1>-{{ fixString }}'
+
+Reload systemctl daemon ({{ stig_id }}):
+  module.run:
+    - name: service.systemctl_reload
+    - watch:
+      - file: 'Require Authentication for Single User Mode'
+
+Restart Rescue Service ({{ stig_id }}):
+  service.running:
+    - name: 'rescue'
+    - enable: true
+    - reload: false
+    - watch:
+      - module: 'Reload systemctl daemon ({{ stig_id }})'
+
 {%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
@@ -19,7 +19,7 @@
 {%- set helperLoc = tpldir ~ '/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set cfgFile = '/usr/lib/systemd/system/rescue.service' %}
-{%- set fixString = '/bin/sh -c "/sbin/sulogin ; /usr/bin/systemctl --fail --no-block default' %}
+{%- set fixString = '/bin/sh -c "/sbin/sulogin ; /usr/bin/systemctl --fail --no-block default"' %}
 
 {{ stig_id }}-description:
   test.show_notification:

--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-611200.sls
@@ -1,0 +1,44 @@
+# Ref Doc:    STIG - RHEL 9 v2r4 (29 Apr 2025)
+# Finding ID: V-258129
+# Rule ID:    SV-258129r958472_rule
+# STIG ID:    RHEL-09-611200
+# SRG ID:     SRG-OS-000080-GPOS-00048
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       RHEL 9 must require authentication to access single-user mode
+#
+# References:
+# NIST SP 800-53 :: AC-3
+# NIST SP 800-53 :: CM-6(a)
+# NIST SP 800-53 :: IA-2
+#
+###########################################################################
+{%- set stig_id = 'RHEL-09-611200' %}
+{%- set helperLoc = tpldir ~ '/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+{%- set cfgFile = '/usr/lib/systemd/system/rescue.service' %}
+{%- set fixString = '/bin/sh -c "/sbin/sulogin ; /usr/bin/systemctl --fail --no-block default' %}
+
+{{ stig_id }}-description:
+  test.show_notification:
+    - text: |
+        ----------------------------------------
+        STIG Finding ID: V-258129
+             The OS must require authentication
+             to access single-user mode
+        ----------------------------------------
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  test.show_notification:
+    - text: |
+        Handler for {{ stig_id }} has been selected for skip.
+{%- else %}
+Require Authentication for Single User Mode:
+  file.replace:
+    - name:  '{{ cfgFile }}'
+    - pattern: '(^ExecStart=)(.*$)'
+    - repl: '\g<1>-{{ fixString }}'
+{%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/init.sls
+++ b/ash-linux/el9/STIGbyID/cat2/init.sls
@@ -1,2 +1,3 @@
 include:
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-255065
+  - ash-linux.el9.STIGbyID.cat2.RHEL-09-611200

--- a/pillar.example
+++ b/pillar.example
@@ -165,3 +165,12 @@
 ##           - ...                         # and `reject`
 ##           - permit_mynetworks
 ##           - check_client_access cidr:/etc/postfix/access
+
+##     Systemd rescue-shell password-protection method: the v2r4 STIGs specify
+##       the first value while the Compliance As Code remediation-content for
+##       Ansible specify the latter method. Absent Pillar content, the state
+##       will set the former. In either case, some scanners may erroneously
+##       identify neither as valid
+##     
+##     rescue_shell_protection: '/usr/lib/systemd/systemd-sulogin-shell rescue'
+##     rescue_shell_protection: '/bin/sh -c "/sbin/sulogin ; /usr/bin/systemctl --fail --no-block default"'


### PR DESCRIPTION
As noted in the `pillar.example` file, this handler will, absent overriding Pillar-data, set the value as described in STIG v2r4's 

* Vul ID: V-258129
* Rule ID: SV-258129r958472_rule
* STIG ID: RHEL-09-611200

Guidance. However, the Ansible content that comes with the `oscap` content from the Compliance As Code project recommends setting a different value. The STIG-recommended guidance is also the behavior implemented in the `systemd-252-51.el9_6.1` RPM.   Therefore, this handler defaults to the STIG's guidance (and the listed RPM's contents).

Regardless of method chosen, some scanners will still flag the service-configuration as non-compliant. This will be noted in the watchmaker FAQs. 

Closes #527 

