### PR TITLE
/usr/lib/... location is preferred in EL9

### DIFF
--- a/ash-linux/el9/RuleById/medium/content_rule_mount_option_tmp_noexec.sls
+++ b/ash-linux/el9/RuleById/medium/content_rule_mount_option_tmp_noexec.sls
@@ -127,7 +127,7 @@
 {%- set mountOptsStig = [
   'noexec',
 ] %}
-{%- set optionsDir = '/etc/systemd/system/tmp.mount.d' %}
+{%- set optionsDir = '/usr/lib/systemd/system/tmp.mount.d' %}
 {%- set optionsFile = optionsDir + '/options.conf' %}
 {%- set combinedOpts = mountOptsDefault + mountOptsStig %}
 


### PR DESCRIPTION
After scan-results were coming back indicating that the mount-options for the `/tmp` filesystem weren't correct, verbosely-executed the relevant formula-content and found an error indicating that the 
`/usr/lib/systemd/system/tmp.mount.d/options.conf` file should be used instead of the `/etc/systemd/system/tmp.mount.d/options.conf` file. Making this change resulted in both the logged error-message going away and the `oscap` utility reporting that the mount-options were now correct:

```
    […elided…]

    Title   Add nodev Option to /tmp
    Rule    xccdf_org.ssgproject.content_rule_mount_option_tmp_nodev
    Result  pass

    Title   Add noexec Option to /tmp
    Rule    xccdf_org.ssgproject.content_rule_mount_option_tmp_noexec
    Result  pass

    Title   Add nosuid Option to /tmp
    Rule    xccdf_org.ssgproject.content_rule_mount_option_tmp_nosuid
    Result  pass

    […elided…]
```

Note that while merging this PR closes #528 the updated content — none that's in the `…/el9/RuleById` hierarchy — does not get run by default. If this content _should_ be executed by default, a later Issue/PR will need to be executed in order for the behavior to be changed.