### PR TITLE
[BUGFIX] Fix error uncovered by watchmaker CI

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-431016.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-431016.sls
@@ -52,7 +52,7 @@ Ensure users and groups have SEL ROLE and TYPE transition-mappings ({{ stig_id }
     - name: '{{ sudoerFile }}'
     - append_if_not_found: False
     - backup: False
-    - pattern: '^(|%)([a-z0-9_^-]*\s\s*)([A-Z]*=\([A-Za-z]*\)\s\s*)(?!(TYPE|ROLE)=[a-z_]*)([A-Za-z]*(|:[A-Za-z]*)$'
+    - pattern: '^(|%)([a-z0-9_^-]*\s\s*)([A-Z]*=\([A-Za-z]*\)\s\s*)(?!(TYPE|ROLE)=[a-z_]*)([A-Za-z]*(|:[A-Za-z]*))$'
     - repl: '\1\2\3 TYPE=sysadm_t ROLE=sysadm_r \5'
 
 Ensure users and groups have consistent SEL ROLE and TYPE transition-mappings ({{ stig_id }}) - {{ sudoerFile }}:


### PR DESCRIPTION
Close the final search-grouping in the "Ensure users and groups have..." state's file.replace `pattern` parameter

Error uncovered watchmaker [PR #3548](https://github.com/plus3it/watchmaker/pull/3548)'s CI testing:

* test-source (rhel9) [job #54579967562](https://github.com/plus3it/watchmaker/actions/runs/19034008020/job/54579967562?pr=3548#logs)
* test-standalone (rhel9) [job #54579967418](https://github.com/plus3it/watchmaker/actions/runs/19034008020/job/54579967418?pr=3548)