### PR TITLE
Fix key-permissions

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-255120.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-255120.sls
@@ -54,7 +54,7 @@
 SSHD hostkey-permission - {{ filename }} ({{ stig_id }}):
   file.managed:
     - group: root
-    - mode: '0640'
+    - mode: '0600'
     - name: '{{ host_ssh_key_files }}'
     - selinux:
         serange: 's0'


### PR DESCRIPTION
STIGs specify 0640, however, the SSHD in current versions of RHEL 9 will refuse to load keys set that permissively, causing the service to fail to start when ALL keys are unloadable. This update changes the mode applied from `0640` to `0600`. This allows the SSHD to load its keys _and_ meets the "or _less_ permissive" [STIG-compliance requirement](https://stigaview.com/products/rhel9/v1r1/RHEL-09-255120/).

Closes #548 