### PR TITLE
Prevent "error" message from being emitted

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-213105.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-213105.sls
@@ -1,7 +1,19 @@
-# Ref Doc:    STIG - RHEL 9 v2r4
-# Finding ID: V-257816
-# Rule ID:    content_rule_sysctl_user_max_user_namespaces_no_remediation_rule
-# STIG ID:    RHEL-09-213105
+# Ref Doc:
+#   - STIG - RHEL 9 v2r5
+#   - STIG - OEL  9 v1r2
+#   - STIG - Alma 9 v1r3
+# Finding ID:
+#   - RHEL: V-257816
+#   - OEL:  V-271727
+#   - Alma: V-269284
+# Rule ID:
+#   - RHEL: SV-257816r1106435_rule
+#   - OEL:  SV-271727r1091893_rule
+#   - Alma: SV-269284r1101813_rule
+# STIG ID:
+#   - RHEL: RHEL-09-213105
+#   - OEL:  OL09-00-002370
+#   - Alma: ALMA-09-023010
 # SRG ID:     SRG-OS-000480-GPOS-00227
 #
 # Finding Level: medium
@@ -18,7 +30,14 @@
 #     -  SP 800-53 Revision 4 :: CM-6 b
 #
 ###########################################################################
-{%- set stig_id = 'RHEL-09-213105' %}
+{%- set stigIdByVendor = {
+    'AlmaLinux': 'ALMA-09-023010',
+    'CentOS Stream': 'RHEL-09-213105',
+    'OEL': 'OL09-00-002370',
+    'RedHat': 'RHEL-09-213105',
+    'Rocky': 'RHEL-09-213105',
+} %}
+{%- set stig_id = stigIdByVendor[salt.grains.get('os')] %}
 {%- set helperLoc = tpldir ~ '/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
 {%- set searchDirs =[
@@ -30,12 +49,23 @@
 ] %}
 {%- set newSysctlFile = '/etc/sysctl.d/99-max-user-namespace.conf' %}
 {%- set sysctlFiles = [] %}
+{%- for searchDir in searchDirs %}
+  {%- do sysctlFiles.extend(
+      salt.file.find(
+        searchDir,
+        type='f',
+        name='*.conf',
+        grep='user\.max_user_namespaces'
+      )
+    )
+   %}
+{%- endfor %}
 
 {{ stig_id }}-description:
   test.show_notification:
     - text: |
         --------------------------------------
-        STIG Finding ID: V-257816
+        STIG Finding ID: {{ stig_id }}
              The OS must disable the use of
              user namespaces
         --------------------------------------
@@ -46,16 +76,22 @@ notify_{{ stig_id }}-skipSet:
     - text: |
         Handler for {{ stig_id }} has been selected for skip.
 {%- else %}
-  {%- for searchDir in searchDirs %}
-    {%- do sysctlFiles.extend(salt.file.find(searchDir, type='f', name='*.conf', grep='user\.max_user_namespaces')) %}
-  {%- endfor %}
-  {% if sysctlFiles|length == 0 %}
+  {%- for sysctlFile in sysctlFiles %}
+Fix user.max_user_namespaces in {{ sysctlFile }}:
+  file.replace:
+    - name: '{{ sysctlFile }}'
+    - pattern: '^(\s*|#(\s*|))(user\.max_user_namespaces)(\s*=\s*).*$'
+    - repl: '\3 = 0'
+    - watch_in:
+      - service: 'Re-read kernel module-config files (max_user_namespaces)'
+  {%- else %}
 Ensure syctemctl settings-file exists:
   file.managed:
     - name: '{{ newSysctlFile }}'
     - create: True
     - group: 'root'
     - mode: '0644'
+    - replace: False
     - selinux:
         serange: 's0'
         serole: 'object_r'
@@ -67,13 +103,16 @@ Add user.max_user_namespaces in {{ newSysctlFile }}:
   file.append:
     - name: '{{ newSysctlFile }}'
     - text: 'user.max_user_namespaces = 0'
-  {%- else %}
-    {%- for sysctlFile in sysctlFiles %}
-Fix user.max_user_namespaces in {{ sysctlFile }}:
-  file.replace:
-    - name: '{{ sysctlFile }}'
-    - pattern: '^(\s*|#(\s*|))(user\.max_user_namespaces)(\s*=\s*).*$'
-    - repl: '\3 = 0'
-    {%- endfor %}
-  {%- endif %}
+    - watch:
+      - file: 'Ensure syctemctl settings-file exists'
+    - watch_in:
+      - service: 'Re-read kernel module-config files (max_user_namespaces)'
+  {%- endfor %}
 {%- endif %}
+
+Re-read kernel module-config files (max_user_namespaces):
+  service.running:
+    - name: systemd-modules-load
+    - enable: true
+    - reload: false
+


### PR DESCRIPTION
Closes #584 by suppressing the message:

    Neither 'source' nor 'contents' nor 'contents_pillar'
    nor 'contents_grains' was defined, yet 'replace' was
    set to 'True'. As there is no source to replace the
    file with, 'replace' has been set to 'False' to avoid
    reading the file unnecessarily.

From being displayed when creating a null-file

While we're here:
- Reorganize to match newer layout standards
- Use platform-specific finding-ID mappings
- Ensure sysctl updates are read