### PR TITLE
Implements "The OS must not show boot up messages" for Alma Linux 9 operating environments

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/ALMA-09-043800.sls
+++ b/ash-linux/el9/STIGbyID/cat2/ALMA-09-043800.sls
@@ -29,6 +29,7 @@
     'RedHat': 'ALMA-09-043800',
     'Rocky': 'ALMA-09-043800',
 } %}
+{%- set osName = salt.grains.get('os') %}
 {%- set stig_id = stigIdByVendor[salt.grains.get('os')] %}
 {%- set helperLoc = tpldir ~ '/files' %}
 {%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
@@ -47,10 +48,18 @@ notify_{{ stig_id }}-skipSet:
   test.show_notification:
     - text: |
         Handler for {{ stig_id }} has been selected for skip.
-{%- else %}
+{%- elif osName == 'AlmaLinux' %}
 Suppress boot messages ({{ stig_id }}):
   cmd.run:
     - name: 'grubby --update-kernel=ALL --args=quiet'
     - unless:
       - 'grubby --info=ALL | grep --quiet quiet'
+{%- else %}
+Skip Reason ({{ stig_id }}):
+  test.show_notification:
+    - text: |-
+        ----------------------------------------
+        STIG Finding ID: {{ stig_id }}
+             Not valid for distro '{{ osName }}'
+        ----------------------------------------
 {%- endif %}


### PR DESCRIPTION
Closes #564.

When initially run on Alma Linux 9 platforms:

```yaml
# salt-call -c /opt/watchmaker/salt/ state.sls ash-linux.el9.STIGbyID.cat2.ALMA-09-043800
local:
----------
          ID: ALMA-09-043800-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-043800
                  The OS must must not show boot up
                  messages
              ----------------------------------------
     Started: 18:19:45.797019
    Duration: 0.76 ms
     Changes:
----------
          ID: Suppress boot messages (ALMA-09-043800)
    Function: cmd.run
        Name: grubby --update-kernel=ALL --args=quiet
      Result: True
     Comment: Command "grubby --update-kernel=ALL --args=quiet" run
     Started: 18:19:45.798408
    Duration: 1300.503 ms
     Changes:
              ----------
              pid:
                  15262
              retcode:
                  0
              stderr:
              stdout:

Summary for local
------------
Succeeded: 2 (changed=1)
Failed:    0
------------
Total states run:     2
Total run time:   1.301 s
```
When re-run on Alma Linux 9 platforms:

```yaml
# salt-call -c /opt/watchmaker/salt/ state.sls ash-linux.el9.STIGbyID.cat2.ALMA-09-043800
local:
----------
          ID: ALMA-09-043800-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-043800
                  The OS must must not show boot up
                  messages
              ----------------------------------------
     Started: 18:21:32.066569
    Duration: 0.826 ms
     Changes:
----------
          ID: Suppress boot messages (ALMA-09-043800)
    Function: cmd.run
        Name: grubby --update-kernel=ALL --args=quiet
      Result: True
     Comment: unless condition is true
     Started: 18:21:32.068021
    Duration: 1513.596 ms
     Changes:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   1.514 s
```
When 

When run on _other than_ Alma Linux 9 platforms:
```yaml
# salt-call -c /opt/watchmaker/salt/ state.sls ash-linux.el9.STIGbyID.cat2.ALMA-09-043800
local:
----------
          ID: ALMA-09-043800-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-043800
                  The OS must must not show boot up
                  messages
              ----------------------------------------
     Started: 18:22:13.983591
    Duration: 0.74 ms
     Changes:
----------
          ID: Skip Reason (ALMA-09-043800)
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-043800
                   Not valid for distro 'Rocky'
              ----------------------------------------
     Started: 18:22:13.984477
    Duration: 0.499 ms
     Changes:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   1.239 ms
```