### PR TITLE
Address "OS audit system must protect logon UIDs from unauthorized change" finding

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
@@ -1,0 +1,85 @@
+# Ref Doc:
+#   - STIG - RHEL 9 v2r6      (01 Oct 2025)
+#   - STIG - OEL 9 v1r3       (01 Oct 2025)
+#   - STIG - AlmaLinux 9 v1r4 (01 Oct 2025)
+#   - STIG - AL2023 v1r1      (14 Jul 2025)
+# Finding ID:
+#   - RHEL:   V-258228
+#   - OEL:    V-271885
+#   - Alma:   V-269544
+#   - AL2023: V-274187
+# Rule ID:
+#   - RHEL:   SV-258228r991572_rule
+#   - OEL:    SV-271885r1092367_rule
+#   - Alma:   SV-269544r1050427_rule
+#   - AL2023: SV-274187r1120715_rule
+# STIG ID:
+#   - RHEL-09-654270
+#   - OL09-00-008000
+#   - ALMA-09-056780
+#   - AZLX-23-005000
+# SRG ID:     SRG-OS-000462-GPOS-00206
+#   - SRG-OS-000057-GPOS-00027
+#   - SRG-OS-000058-GPOS-00028
+#   - SRG-OS-000059-GPOS-00029
+#   - SRG-OS-000475-GPOS-00220
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The OS must audit system must protect logon UIDs from unauthorized change
+#
+# References:
+#   CCI:
+#     - CCI-000162
+#       NIST:
+#         - SP 800-53 :: AU-9
+#         - SP 800-53A :: AU-9.1
+#         - SP 800-53 Revision 4 :: AU-9
+#     - CCI-000163
+#       NIST:
+#         - SP 800-53 :: AU-9
+#         - SP 800-53A :: AU-9.1
+#         - SP 800-53 Revision 4 :: AU-9
+#     - CCI-000164
+#       NIST:
+#         - SP 800-53 :: AU-9
+#         - SP 800-53A :: AU-9.1
+#         - SP 800-53 Revision 4 :: AU-9
+#     - CCI-000172
+#       NIST:
+#         - SP 800-53 :: AU-12 c
+#         - SP 800-53A :: AU-12.1 (iv)
+#         - SP 800-53 Revision 4 :: AU-12 c
+#
+###########################################################################
+{%- set stigIdByVendor = {
+    'AlmaLinux': 'ALMA-09-056780',
+    'Amazon': 'AZLX-23-005000',
+    'CentOS Stream': 'RHEL-09-654270',
+    'OEL': 'OL09-00-008000',
+    'RedHat': 'RHEL-09-654270',
+    'Rocky': 'RHEL-09-654270',
+} %}
+{%- set osName = salt.grains.get('os') %}
+{%- set stig_id = stigIdByVendor[osName] %}
+{%- set helperLoc = tpldir ~ '/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+
+{{ stig_id }}-description:
+  test.show_notification:
+    - text: |-
+        ----------------------------------------
+        STIG Finding ID: {{ stig_id }}
+            The OS must audit system must
+            protect logon UIDs from unauthorized
+            change
+        ----------------------------------------
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  test.show_notification:
+    - text: |
+        Handler for {{ stig_id }} has been selected for skip.
+{%- else %}
+{%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
@@ -125,9 +125,9 @@ Persistently protect logon UIDs from unauthorized change via {{ auditFile }} ({{
 Live-update audit-config to protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }}):
   cmd.run:
     - name: 'auditctl --loginuid-immutable'
-    - onchanges:
+    - watch:
       - file: 'Persistently protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }})'
     - unless:
-      - 'auditctl -s | grep -qP"loginuid_immutable\s\s*1\s\s*locked"'
+      - 'auditctl -s | grep -qP "loginuid_immutable\s\s*1\s\s*locked"'
   {%- endfor %}
 {%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-654270.sls
@@ -109,7 +109,7 @@ Ensure {{ auditFileDflt }} file exists ({{ stig_id }}):
         seuser: 'system_u'
     - user: 'root'
   {%- for auditFile in auditFiles %}
-Protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }}):
+Persistently protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }}):
   file.replace:
     - name: '{{ auditFile }}'
     - append_if_not_found: True
@@ -121,5 +121,13 @@ Protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }}):
     - repl: '--loginuid-immutable'
     - watch:
       - file: 'Ensure {{ auditFileDflt }} file exists ({{ stig_id }})'
+
+Live-update audit-config to protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }}):
+  cmd.run:
+    - name: 'auditctl --loginuid-immutable'
+    - onchanges:
+      - file: 'Persistently protect logon UIDs from unauthorized change via {{ auditFile }} ({{ stig_id }})'
+    - unless:
+      - 'auditctl -s | grep -qP"loginuid_immutable\s\s*1\s\s*locked"'
   {%- endfor %}
 {%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/init.sls
+++ b/ash-linux/el9/STIGbyID/cat2/init.sls
@@ -28,3 +28,4 @@ include:
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-654075
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-654080
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-654140
+  - ash-linux.el9.STIGbyID.cat2.RHEL-09-654270


### PR DESCRIPTION
# Testing:

Handler works on Alma and Rocky Linux 9, Red Hat and Oracle Enterprise Linux 9 and Amazon Linux 2023. Results shown are for Alma Linux 9.

## Setting not present (anywhere)
```yaml
----------
          ID: ALMA-09-056780-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056780
                  The OS must audit system must
                  protect logon UIDs from unauthorized
                  change
              ----------------------------------------
     Started: 17:04:58.116805
    Duration: 0.585 ms
     Changes:
----------
          ID: Ensure /etc/audit/rules.d/audit.rules file exists (ALMA-09-056780)
    Function: file.managed
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: File /etc/audit/rules.d/audit.rules exists with proper permissions. No changes made.
     Started: 17:04:58.117508
    Duration: 4.808 ms
     Changes:
----------
          ID: Persistently protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: file.replace
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: Changes were made
     Started: 17:04:58.128336
    Duration: 4.721 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -40,3 +40,4 @@
                   # Set per rule ALMA-09-050620
                   -a always,exit -F arch=b64 -F path=/usr/bin/ssh-keysign -F perm=x -F auid>=1000 -F auid!=unset -k privileged-ssh

                  +# Set per rule ALMA-09-056780
                  --loginuid-immutable
----------
          ID: Live-update audit-config to protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: cmd.run
        Name: auditctl --loginuid-immutable
      Result: True
     Comment: Command "auditctl --loginuid-immutable" run
     Started: 17:04:58.134104
    Duration: 18.073 ms
     Changes:
              ----------
              pid:
                  37996
              retcode:
                  0
              stderr:
              stdout:
----------
```
## Setting already present (everywhere)
```yaml
----------
          ID: ALMA-09-056780-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056780
                  The OS must audit system must
                  protect logon UIDs from unauthorized
                  change
              ----------------------------------------
     Started: 17:18:57.857810
    Duration: 0.698 ms
     Changes:
----------
          ID: Ensure /etc/audit/rules.d/audit.rules file exists (ALMA-09-056780)
    Function: file.managed
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: File /etc/audit/rules.d/audit.rules exists with proper permissions. No changes made.
     Started: 17:18:57.860891
    Duration: 9.828 ms
     Changes:
----------
          ID: Persistently protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: file.replace
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: No changes needed to be made
     Started: 17:18:59.564439
    Duration: 6.821 ms
     Changes:
----------
          ID: Live-update audit-config to protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: cmd.run
        Name: auditctl --loginuid-immutable
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 17:18:59.571885
    Duration: 0.004 ms
     Changes:------------
```

## Setting present in file but not running configuration

This scenario should be _very_ rare and required significant "fiddling" to provoke

```yaml
----------
          ID: ALMA-09-056780-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056780
                  The OS must audit system must
                  protect logon UIDs from unauthorized
                  change
              ----------------------------------------
     Started: 18:15:46.219133
    Duration: 0.805 ms
     Changes:
----------
          ID: Ensure /etc/audit/rules.d/audit.rules file exists (ALMA-09-056780)
    Function: file.managed
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: The file /etc/audit/rules.d/audit.rules is set to be changed
     Started: 18:15:46.223348
    Duration: 7595.848 ms
     Changes:
              ----------
              selinux:
                  ----------
                  New:
                      User: system_u
                  Old:
                      User: unconfined_u
----------
          ID: Persistently protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: file.replace
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: No changes needed to be made
     Started: 18:15:56.530230
    Duration: 9.157 ms
     Changes:
----------
          ID: Live-update audit-config to protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: cmd.run
        Name: auditctl --loginuid-immutable
      Result: True
     Comment: Command "auditctl --loginuid-immutable" run
     Started: 18:15:56.540079
    Duration: 43.699 ms
     Changes:
              ----------
              pid:
                  2170
              retcode:
                  0
              stderr:
              stdout:
------------
```

## Setting present in running configuration but not file

This scenario should also be _very_ rare (and required significant "fiddling" to provoke)

```yaml
----------
          ID: ALMA-09-056780-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056780
                  The OS must audit system must
                  protect logon UIDs from unauthorized
                  change
              ----------------------------------------
     Started: 18:30:55.850277
    Duration: 0.864 ms
     Changes:
----------
          ID: Ensure /etc/audit/rules.d/audit.rules file exists (ALMA-09-056780)
    Function: file.managed
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: The file /etc/audit/rules.d/audit.rules is set to be changed
     Started: 18:30:55.857606
    Duration: 6252.48 ms
     Changes:
              ----------
              selinux:
                  ----------
                  New:
                      User: system_u
                  Old:
                      User: unconfined_u
----------
          ID: Persistently protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: file.replace
        Name: /etc/audit/rules.d/audit.rules
      Result: True
     Comment: Changes were made
     Started: 18:31:04.768656
    Duration: 12.427 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -46,3 +46,4 @@

                   # Set per rule ALMA-09-056780

                  +# Set per rule ALMA-09-056780
                  --loginuid-immutable
----------
          ID: Live-update audit-config to protect logon UIDs from unauthorized change via /etc/audit/rules.d/audit.rules (ALMA-09-056780)
    Function: cmd.run
        Name: auditctl --loginuid-immutable
      Result: True
     Comment: unless condition is true
     Started: 18:31:04.781718
    Duration: 18.709 ms
     Changes:
------------
```

Closes #551 