### PR TITLE
Implement handler for "OS must use cryptographic mechanisms to protect the integrity of audit tools" finding

### DIFF
--- a/ash-linux/el9/STIGbyID/cat2/RHEL-09-651025.sls
+++ b/ash-linux/el9/STIGbyID/cat2/RHEL-09-651025.sls
@@ -1,0 +1,71 @@
+# Ref Doc:
+#   - STIG - RHEL 9 v2r6      (01 Oct 2025)
+#   - STIG - OEL 9 v1r3       (01 Oct 2025)
+#   - STIG - AlmaLinux 9 v1r4 (01 Oct 2025)
+#   - STIG - AL2023 v1r1      (14 Jul 2025)
+
+# Finding ID:
+#   - RHEL:   V-258137
+#   - OEL:    V-271569
+#   - Alma:   V-269545
+#   - AL2023: V-274026
+# Rule ID:
+#   - RHEL:   SV-258137r1102081_rule
+#   - OEL:    SV-271569r1091419_rule
+#   - Alma:   SV-269545r1050428_rule
+#   - AL2023: SV-274026r1120066_rule
+# STIG ID:
+#   - RHEL-09-651025
+#   - OL09-00-000710
+#   - ALMA-09-056890
+#   - AZLX-23-NNNNNN
+# SRG ID:     SRG-OS-000256-GPOS-00097
+#   - SRG-OS-000257-GPOS-00098
+#   - SRG-OS-000258-GPOS-00099
+#   - SRG-OS-000278-GPOS-00108
+#
+# Finding Level: medium
+#
+# Rule Summary:
+#       The OS must must use cryptographic mechanisms to protect the integrity
+#       of audit tools
+#
+# References:
+#   CCI:
+#     - CCI-000213
+#   NIST:
+#     - SP 800-53 ::
+#     - SP 800-53A ::
+#     - SP 800-53 Revision 4 ::
+#
+###########################################################################
+{%- set stigIdByVendor = {
+    'AlmaLinux': 'ALMA-09-056890',
+    'Amazon': 'AZLX-23-NNNNNN',
+    'CentOS Stream': 'RHEL-09-651025',
+    'OEL': 'OL09-00-000710',
+    'RedHat': 'RHEL-09-651025',
+    'Rocky': 'RHEL-09-651025',
+} %}
+{%- set osName = salt.grains.get('os') %}
+{%- set stig_id = stigIdByVendor[osName] %}
+{%- set helperLoc = tpldir ~ '/files' %}
+{%- set skipIt = salt.pillar.get('ash-linux:lookup:skip-stigs', []) %}
+
+{{ stig_id }}-description:
+  test.show_notification:
+    - text: |-
+        ----------------------------------------
+        STIG Finding ID: {{ stig_id }}
+            The OS must must use cryptographic
+            mechanisms to protect the integrity
+            of audit tools
+        ----------------------------------------
+
+{%- if stig_id in skipIt %}
+notify_{{ stig_id }}-skipSet:
+  test.show_notification:
+    - text: |
+        Handler for {{ stig_id }} has been selected for skip.
+{%- else %}
+{%- endif %}

--- a/ash-linux/el9/STIGbyID/cat2/init.sls
+++ b/ash-linux/el9/STIGbyID/cat2/init.sls
@@ -20,6 +20,7 @@ include:
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-611085
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-611170
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-611200
+  - ash-linux.el9.STIGbyID.cat2.RHEL-09-651025
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-652040
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-652045
   - ash-linux.el9.STIGbyID.cat2.RHEL-09-652055


### PR DESCRIPTION
This PR closes #550.

# Execution-note

The current Compliance as Code that the ash-linux-formula executes _already_ lays down AIDE content:

```
/usr/sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
/usr/sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
```

The automation in this PR will lay down what's specified in the October 2025 STIGs:

```
/usr/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
/usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
/usr/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
/usr/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
/usr/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
/usr/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
```

If and only if the Compliance as Code content is (somehow) absent:

Will update Known Findings (for EL9) content in the [watchmaker documentation](https://watchmaker.readthedocs.io/en/stable/findings/el9.html) to reflect this possible (false) finding.

# Testing

## Compliance as Code Content (Already) Present:

```yaml
----------
          ID: ALMA-09-056890-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056890
                  The OS must must use cryptographic
                  mechanisms to protect the integrity
                  of audit tools
              ----------------------------------------
     Started: 14:42:58.429030
    Duration: 0.781 ms
     Changes:
----------
          ID: Ensure AIDE software is present (ALMA-09-056890)
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 14:42:59.477039
    Duration: 159.319 ms
     Changes:
----------
          ID: Ensure /etc/aide.conf exists (ALMA-09-056890)
    Function: file.managed
        Name: /etc/aide.conf
      Result: True
     Comment: File /etc/aide.conf exists with proper permissions. No changes made.
     Started: 14:43:00.345214
    Duration: 8.763 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/auditctl in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.362010
    Duration: 23.439 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/auditd in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.391457
    Duration: 16.063 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/augenrules in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.415851
    Duration: 15.397 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/aureport in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.439636
    Duration: 16.072 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/ausearch in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.463903
    Duration: 16.422 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/autrace in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: unless condition is true
     Started: 14:43:00.488524
    Duration: 15.611 ms
     Changes:
------------
```

## Compliance as Code Content Absent:

```yaml
----------
          ID: ALMA-09-056890-description
    Function: test.show_notification
      Result: True
     Comment: ----------------------------------------
              STIG Finding ID: ALMA-09-056890
                  The OS must must use cryptographic
                  mechanisms to protect the integrity
                  of audit tools
              ----------------------------------------
     Started: 14:54:11.573892
    Duration: 0.909 ms
     Changes:
----------
          ID: Ensure AIDE software is present (ALMA-09-056890)
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 14:54:12.623045
    Duration: 162.376 ms
     Changes:
----------
          ID: Ensure /etc/aide.conf exists (ALMA-09-056890)
    Function: file.managed
        Name: /etc/aide.conf
      Result: True
     Comment: File /etc/aide.conf exists with proper permissions. No changes made.
     Started: 14:54:13.372446
    Duration: 8.117 ms
     Changes:
----------
          ID: Ensure monitoring of /usr/sbin/auditctl in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.388746
    Duration: 34.443 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -302,3 +302,4 @@
                   #
                   #=/lost\+found    DIR
                   #=/home           DIR
                  +# Set per rule ALMA-09-056890
                  /usr/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512

----------
          ID: Ensure monitoring of /usr/sbin/auditd in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.428700
    Duration: 31.824 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -305,3 +305,4 @@
                   # Set per rule ALMA-09-056890
                   /usr/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512

                  +# Set per rule ALMA-09-056890
                  /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512

----------
          ID: Ensure monitoring of /usr/sbin/augenrules in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.466000
    Duration: 31.233 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -308,3 +308,4 @@
                   # Set per rule ALMA-09-056890
                   /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512

                  +# Set per rule ALMA-09-056890
                  /usr/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512

----------
          ID: Ensure monitoring of /usr/sbin/aureport in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.502738
    Duration: 29.702 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -311,3 +311,4 @@
                   # Set per rule ALMA-09-056890
                   /usr/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512

                  +# Set per rule ALMA-09-056890
                  /usr/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512

----------
          ID: Ensure monitoring of /usr/sbin/ausearch in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.537968
    Duration: 29.961 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -314,3 +314,4 @@
                   # Set per rule ALMA-09-056890
                   /usr/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512

                  +# Set per rule ALMA-09-056890
                  /usr/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512

----------
          ID: Ensure monitoring of /usr/sbin/autrace in /etc/aide.conf (ALMA-09-056890)
    Function: file.replace
        Name: /etc/aide.conf
      Result: True
     Comment: Changes were made
     Started: 14:54:13.573403
    Duration: 30.499 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -317,3 +317,4 @@
                   # Set per rule ALMA-09-056890
                   /usr/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512

                  +# Set per rule ALMA-09-056890
                  /usr/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
------------
```